### PR TITLE
Implement pricing_grid module

### DIFF
--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,2 @@
+tool: claude-code
+profile: core

--- a/openspec/specs/pricing_grid/spec.md
+++ b/openspec/specs/pricing_grid/spec.md
@@ -1,0 +1,48 @@
+# Pricing Grid
+
+## Purpose
+
+Generate and manage the geometric price ladder that defines all valid order price levels. This is the backbone of the HIP-2 algorithm — prices are NOT computed from an AMM formula but from discrete grid positions.
+
+## Parameters
+
+- `start_px: float` — The initial price of the range (px_0)
+- `n_orders: int` — Number of price levels in the grid
+- `tick_size: float = 0.003` — Multiplicative spacing between levels (0.3% default per HIP-2)
+
+## Core Function
+
+```
+px_0 = start_px
+px_i = round(px_{i-1} * (1 + tick_size))    for i in 1..n_orders-1
+```
+
+The grid is a fixed array computed once at initialization. It does NOT shift with market conditions — the market maker's position within the grid shifts instead.
+
+## Outputs
+
+- `levels: list[float]` — The complete ordered price ladder, ascending
+- `level_for_price(px) -> int | None` — Nearest grid level index for a given price
+- `price_at_level(i) -> float` — Price at grid index i
+
+## Invariants
+
+1. `len(levels) == n_orders`
+2. `levels[0] == start_px`
+3. For all i: `levels[i+1] / levels[i]` ≈ `1 + tick_size` (subject to rounding)
+4. Grid is strictly monotonically increasing
+5. Grid is deterministic — same parameters always produce the same levels
+6. Grid is computed once and is immutable for the lifetime of a strategy instance
+
+## Precision
+
+Prices must be rounded to the market's tick size (varies per spot pair — fetch from `spot_meta()`). Use the exchange's rounding convention, not arbitrary precision. The `round()` in the recurrence refers to the exchange's significant-figure rounding, which should be configurable.
+
+## Edge Cases
+
+- Very small `start_px` (sub-cent tokens): Ensure rounding doesn't collapse adjacent levels to the same price. If `round(px_{i-1} * 1.003) == px_{i-1}`, the grid is degenerate — raise an error.
+- Very large `n_orders`: Grid extends to very high prices. No inherent limit, but memory is linear in n_orders.
+
+## Dependencies
+
+None. This is a pure math module with zero I/O.

--- a/src/pyperliquidity/pricing_grid.py
+++ b/src/pyperliquidity/pricing_grid.py
@@ -1,0 +1,99 @@
+"""Geometric price ladder generation and level lookup for HIP-2 market making."""
+
+from __future__ import annotations
+
+import math
+from bisect import bisect_left
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+
+def _default_round(px: float) -> float:
+    """Round to 8 significant figures."""
+    if px == 0:
+        return 0.0
+    magnitude = math.floor(math.log10(abs(px))) + 1
+    return round(px, 8 - magnitude)
+
+
+@dataclass(frozen=True)
+class PricingGrid:
+    """Immutable geometric price grid for HIP-2 market making.
+
+    Parameters
+    ----------
+    start_px : float
+        The initial price of the range (px_0).
+    n_orders : int
+        Number of price levels in the grid.
+    tick_size : float
+        Multiplicative spacing between levels (default 0.3% per HIP-2).
+    round_fn : Callable[[float], float]
+        Rounding function applied at each step of the recurrence.
+    """
+
+    start_px: float
+    n_orders: int
+    tick_size: float = 0.003
+    round_fn: Callable[[float], float] = _default_round
+    _levels: tuple[float, ...] = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        prices: list[float] = [self.round_fn(self.start_px)]
+        for _ in range(self.n_orders - 1):
+            next_px = self.round_fn(prices[-1] * (1 + self.tick_size))
+            if next_px == prices[-1]:
+                raise ValueError(
+                    f"Degenerate grid: rounding collapsed level {len(prices)} "
+                    f"to same price as level {len(prices) - 1} ({next_px}). "
+                    f"Increase rounding precision or tick_size."
+                )
+            prices.append(next_px)
+        # Bypass frozen restriction for init
+        object.__setattr__(self, "_levels", tuple(prices))
+
+    @property
+    def levels(self) -> tuple[float, ...]:
+        """The complete ordered price ladder, ascending."""
+        return self._levels
+
+    def price_at_level(self, i: int) -> float:
+        """Price at grid index *i*. Raises IndexError if out of bounds."""
+        if i < 0 or i >= len(self._levels):
+            raise IndexError(f"Level index {i} out of range [0, {len(self._levels) - 1}]")
+        return self._levels[i]
+
+    def level_for_price(self, px: float) -> int | None:
+        """Nearest grid level index for *px*, or None if outside the grid range.
+
+        Uses binary search for O(log n) lookup. When *px* falls exactly between
+        two levels, the lower index is returned (tie-breaking rule).
+
+        Returns None if *px* is below levels[0] by more than half a tick spacing
+        or above levels[-1] by more than half a tick spacing.
+        """
+        levels = self._levels
+        if not levels:
+            return None
+
+        half_tick_low = levels[0] * self.tick_size / 2
+        half_tick_high = levels[-1] * self.tick_size / 2
+
+        if px < levels[0] - half_tick_low:
+            return None
+        if px > levels[-1] + half_tick_high:
+            return None
+
+        idx = bisect_left(levels, px)
+
+        if idx == 0:
+            return 0
+        if idx == len(levels):
+            return len(levels) - 1
+
+        # Compare distance to left and right neighbors
+        left = levels[idx - 1]
+        right = levels[idx]
+        if px - left <= right - px:  # <= gives lower-index tie-breaking
+            return idx - 1
+        return idx

--- a/tests/test_pricing_grid.py
+++ b/tests/test_pricing_grid.py
@@ -1,0 +1,174 @@
+"""Tests for the PricingGrid module."""
+
+import pytest
+
+from pyperliquidity.pricing_grid import PricingGrid
+
+# --- 3.1 Standard grid generation ---
+
+
+class TestGridGeneration:
+    def test_correct_length(self) -> None:
+        grid = PricingGrid(start_px=1.0, n_orders=10)
+        assert len(grid.levels) == 10
+
+    def test_starts_at_start_px(self) -> None:
+        grid = PricingGrid(start_px=2.5, n_orders=5)
+        assert grid.levels[0] == 2.5
+
+    def test_monotonically_increasing(self) -> None:
+        grid = PricingGrid(start_px=1.0, n_orders=100)
+        for i in range(len(grid.levels) - 1):
+            assert grid.levels[i] < grid.levels[i + 1], (
+                f"Level {i} ({grid.levels[i]}) not less than level {i+1} ({grid.levels[i+1]})"
+            )
+
+    def test_spacing_approximately_tick_size(self) -> None:
+        grid = PricingGrid(start_px=1.0, n_orders=50, tick_size=0.003)
+        for i in range(len(grid.levels) - 1):
+            ratio = grid.levels[i + 1] / grid.levels[i]
+            assert abs(ratio - 1.003) < 0.001
+
+
+# --- 3.2 Determinism ---
+
+
+class TestDeterminism:
+    def test_identical_params_produce_identical_levels(self) -> None:
+        g1 = PricingGrid(start_px=1.0, n_orders=50, tick_size=0.003)
+        g2 = PricingGrid(start_px=1.0, n_orders=50, tick_size=0.003)
+        assert g1.levels == g2.levels
+
+    def test_deterministic_with_custom_round_fn(self) -> None:
+        def rfn(px: float) -> float:
+            return round(px, 4)
+
+        g1 = PricingGrid(start_px=0.5, n_orders=20, round_fn=rfn)
+        g2 = PricingGrid(start_px=0.5, n_orders=20, round_fn=rfn)
+        assert g1.levels == g2.levels
+
+
+# --- 3.3 Custom tick_size and round_fn ---
+
+
+class TestCustomParameters:
+    def test_custom_tick_size(self) -> None:
+        grid = PricingGrid(start_px=1.0, n_orders=10, tick_size=0.01)
+        for i in range(len(grid.levels) - 1):
+            ratio = grid.levels[i + 1] / grid.levels[i]
+            assert abs(ratio - 1.01) < 0.001
+
+    def test_custom_round_fn(self) -> None:
+        grid = PricingGrid(start_px=1.0, n_orders=5, round_fn=lambda px: round(px, 4))
+        for level in grid.levels:
+            assert level == round(level, 4)
+
+
+# --- 3.4 Degenerate grid detection ---
+
+
+class TestDegenerateGrid:
+    def test_degenerate_raises_value_error(self) -> None:
+        # 0.000001 * 1.003 = 0.000001003, rounded to 6 decimals = 0.000001
+        with pytest.raises(ValueError, match="Degenerate grid"):
+            PricingGrid(
+                start_px=0.000001,
+                n_orders=5,
+                tick_size=0.003,
+                round_fn=lambda px: round(px, 6),
+            )
+
+    def test_valid_sub_cent_token(self) -> None:
+        # 0.001 with sufficient precision should work
+        grid = PricingGrid(
+            start_px=0.001,
+            n_orders=10,
+            tick_size=0.003,
+            round_fn=lambda px: round(px, 8),
+        )
+        assert len(grid.levels) == 10
+        for i in range(len(grid.levels) - 1):
+            assert grid.levels[i] < grid.levels[i + 1]
+
+
+# --- 3.5 level_for_price ---
+
+
+class TestLevelForPrice:
+    @pytest.fixture()
+    def grid(self) -> PricingGrid:
+        return PricingGrid(start_px=1.0, n_orders=10, tick_size=0.003)
+
+    def test_exact_match(self, grid: PricingGrid) -> None:
+        for i, level in enumerate(grid.levels):
+            assert grid.level_for_price(level) == i
+
+    def test_between_levels_closer_to_right(self, grid: PricingGrid) -> None:
+        # Price closer to levels[3] than levels[2]
+        px = grid.levels[2] * 0.2 + grid.levels[3] * 0.8
+        assert grid.level_for_price(px) == 3
+
+    def test_between_levels_closer_to_left(self, grid: PricingGrid) -> None:
+        # Price closer to levels[2] than levels[3]
+        px = grid.levels[2] * 0.8 + grid.levels[3] * 0.2
+        assert grid.level_for_price(px) == 2
+
+    def test_price_below_range(self, grid: PricingGrid) -> None:
+        assert grid.level_for_price(0.5) is None
+
+    def test_price_above_range(self, grid: PricingGrid) -> None:
+        assert grid.level_for_price(999.0) is None
+
+    def test_tie_breaking_returns_lower_index(self, grid: PricingGrid) -> None:
+        # Exactly between levels[2] and levels[3]
+        midpoint = (grid.levels[2] + grid.levels[3]) / 2
+        assert grid.level_for_price(midpoint) == 2
+
+    def test_just_below_min_returns_level_0(self, grid: PricingGrid) -> None:
+        # Slightly below levels[0] but within half-tick
+        px = grid.levels[0] - grid.levels[0] * grid.tick_size * 0.1
+        assert grid.level_for_price(px) == 0
+
+    def test_just_above_max_returns_last_level(self, grid: PricingGrid) -> None:
+        # Slightly above levels[-1] but within half-tick
+        px = grid.levels[-1] + grid.levels[-1] * grid.tick_size * 0.1
+        assert grid.level_for_price(px) == len(grid.levels) - 1
+
+
+# --- 3.6 price_at_level ---
+
+
+class TestPriceAtLevel:
+    def test_valid_index(self) -> None:
+        grid = PricingGrid(start_px=1.0, n_orders=5)
+        assert grid.price_at_level(0) == grid.levels[0]
+        assert grid.price_at_level(4) == grid.levels[4]
+
+    def test_out_of_bounds_raises_index_error(self) -> None:
+        grid = PricingGrid(start_px=1.0, n_orders=5)
+        with pytest.raises(IndexError):
+            grid.price_at_level(5)
+
+    def test_negative_index_raises_index_error(self) -> None:
+        grid = PricingGrid(start_px=1.0, n_orders=5)
+        with pytest.raises(IndexError):
+            grid.price_at_level(-1)
+
+
+# --- 3.7 Immutability ---
+
+
+class TestImmutability:
+    def test_levels_is_tuple(self) -> None:
+        grid = PricingGrid(start_px=1.0, n_orders=5)
+        assert isinstance(grid.levels, tuple)
+
+    def test_cannot_assign_attribute(self) -> None:
+        grid = PricingGrid(start_px=1.0, n_orders=5)
+        with pytest.raises(AttributeError):
+            grid.start_px = 2.0  # type: ignore[misc]
+
+    def test_cannot_assign_levels(self) -> None:
+        grid = PricingGrid(start_px=1.0, n_orders=5)
+        with pytest.raises(AttributeError):
+            grid._levels = (1.0, 2.0)  # type: ignore[misc]


### PR DESCRIPTION
## Summary
- Implement `PricingGrid` frozen dataclass generating a geometric price ladder per HIP-2 spec (0.3% default spacing)
- Provides `levels`, `price_at_level(i)`, and `level_for_price(px)` APIs with bisect-based O(log n) lookup
- Configurable rounding function (injectable callable) to support varying spot pair tick sizes
- Degenerate grid detection raises `ValueError` when rounding collapses adjacent levels
- 24 passing pytest tests covering generation, determinism, edge cases, and immutability

## Test plan
- [x] `pytest tests/test_pricing_grid.py` — 24/24 passing
- [ ] Verify downstream modules (inventory, quoting_engine) can consume the grid API

🤖 Generated with [Claude Code](https://claude.com/claude-code)