### PR TITLE
Implement quoting engine module

### DIFF
--- a/openspec/changes/implement-quoting-engine/.openspec.yaml
+++ b/openspec/changes/implement-quoting-engine/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-01

--- a/openspec/changes/implement-quoting-engine/design.md
+++ b/openspec/changes/implement-quoting-engine/design.md
@@ -1,0 +1,79 @@
+## Context
+
+The quoting engine is the central pure-math module in the pipeline. Upstream, `Inventory` tracks effective balances and decomposes them into tranches. Downstream, `order_differ` matches desired orders against live orders by `(side, level_index)`. The quoting engine bridges these: it takes inventory state + price grid and emits a deterministic list of `DesiredOrder` objects.
+
+The `PricingGrid` and `Inventory` modules are already implemented. The `order_differ` is also implemented and expects `DesiredOrder` with a `level_index` field for stable identity matching.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Implement `compute_desired_orders()` as a pure, deterministic function
+- Define `DesiredOrder` dataclass consumed by order_differ
+- Handle all edge cases: empty balances, one-sided inventory, partials, minimum notional filtering
+- Comprehensive test coverage
+
+**Non-Goals:**
+- No I/O, no imports from order_state/ws_state/batch_emitter
+- No stored boundary state — boundary is computed from inputs each call
+- No AMM formula — pricing emerges from grid position
+- No config file parsing — parameters are passed in directly
+
+## Decisions
+
+### 1. Function signature takes primitives, not Inventory
+
+```python
+compute_desired_orders(
+    grid: PricingGrid,
+    boundary_level: int,
+    effective_token: float,
+    effective_usdc: float,
+    order_sz: float,
+    min_notional: float = 0.0,
+) -> list[DesiredOrder]
+```
+
+**Rationale**: The quoting engine should not import or depend on the `Inventory` class. Passing primitives keeps it a pure function with no coupling. The caller (state manager) extracts values from `Inventory` before calling.
+
+**Alternative considered**: Passing `Inventory` directly — rejected because it creates a coupling and makes testing harder. The engine doesn't need allocation logic, just the numbers.
+
+### 2. Boundary level is an explicit input parameter
+
+The boundary level (lowest ask level index) is passed in, not computed internally. The caller determines it from inventory state — `Inventory` already has the context (n_seeded_levels, fill history) to compute this.
+
+**Rationale**: The spec says "computed not stored", but it must come from somewhere. Inventory is where the state lives. The quoting engine is stateless — it just places asks starting at `boundary_level` ascending and bids starting at `boundary_level - 1` descending.
+
+**Alternative considered**: Having the engine compute boundary from n_seeded_levels + fill count — rejected because that would require the engine to track state, violating its pure-function contract.
+
+### 3. DesiredOrder is a frozen dataclass
+
+```python
+@dataclass(frozen=True)
+class DesiredOrder:
+    side: str       # "buy" | "sell"
+    level_index: int
+    price: float
+    size: float
+```
+
+Frozen for immutability and hashability. The order_differ matches on `(side, level_index)`.
+
+### 4. Minimum notional filtering happens at the end
+
+After computing all orders (asks + bids), filter out any where `price * size < min_notional`. This is simpler than trying to redistribute filtered amounts.
+
+**Trade-off**: Filtered partial orders mean slightly less than 100% of balance is quoted. This is acceptable — the alternative (redistributing) adds complexity for marginal benefit.
+
+### 5. Ask-side ordering: ascending from boundary
+
+Asks are placed at levels `boundary_level, boundary_level+1, ...` — full asks first, then partial at the top. This matches HIP-2 behavior where the lowest ask is at the boundary.
+
+### 6. Bid-side ordering: descending from boundary-1
+
+Bids walk down from `boundary_level - 1` to level 0 (or until USDC is exhausted). Full bids first, partial at the bottom.
+
+## Risks / Trade-offs
+
+- **[Float precision]** → Use careful arithmetic; the existing inventory module already handles float clamping. The quoting engine doesn't compound — it reads grid prices directly, so precision is bounded by PricingGrid's rounding.
+- **[Grid overflow]** → If `boundary_level + n_full_asks + (1 if partial)` exceeds grid size, asks are truncated at the grid edge. Same for bids below level 0. This is correct behavior — the grid is finite.
+- **[Minimum notional kills all orders]** → If min_notional is set very high, all orders could be filtered. The function returns an empty list — this is valid and the caller should handle it.

--- a/openspec/changes/implement-quoting-engine/proposal.md
+++ b/openspec/changes/implement-quoting-engine/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The quoting engine is the core HIP-2 algorithm — the pure function that turns inventory state and a price grid into a set of desired orders. Without it, the pipeline from StateManager → OrderDiffer → BatchEmitter has no input. This is the last missing pure-math module before the system can produce quotes.
+
+## What Changes
+
+- Implement `compute_desired_orders()` as a pure, deterministic function: given a `PriceGrid`, effective balances, `order_sz`, boundary level, and minimum notional — return a list of `DesiredOrder` dataclasses
+- Define the `DesiredOrder` dataclass with `side`, `level_index`, `price`, and `size` fields
+- Ask-side: place full asks ascending from boundary, plus one partial if remainder > 0
+- Bid-side: place full bids descending from boundary-1 until USDC exhausted, plus one partial
+- Filter out orders below minimum notional threshold
+- Comprehensive pytest test suite covering all edge cases
+
+## Capabilities
+
+### New Capabilities
+
+_(none — the quoting_engine spec already exists)_
+
+### Modified Capabilities
+
+- `quoting_engine`: Adding `boundary_level` and `min_notional` as explicit parameters to the interface; spec currently omits these details
+
+## Impact
+
+- New file: `src/pyperliquidity/quoting_engine.py`
+- New file: `tests/test_quoting_engine.py`
+- Depends on: `pricing_grid.PricingGrid`, `inventory.Inventory` (for type context only — no runtime import of Inventory needed, just its output values)
+- Downstream consumer: `order_differ` will match on `(side, level_index)` from `DesiredOrder`

--- a/openspec/changes/implement-quoting-engine/specs/quoting_engine/spec.md
+++ b/openspec/changes/implement-quoting-engine/specs/quoting_engine/spec.md
@@ -1,0 +1,128 @@
+## MODIFIED Requirements
+
+### Requirement: compute_desired_orders interface
+The system SHALL expose a `compute_desired_orders` function with the following signature:
+
+```python
+compute_desired_orders(
+    grid: PricingGrid,
+    boundary_level: int,
+    effective_token: float,
+    effective_usdc: float,
+    order_sz: float,
+    min_notional: float = 0.0,
+) -> list[DesiredOrder]
+```
+
+The function SHALL accept `boundary_level` as an explicit integer parameter representing the lowest ask level index on the grid. The function SHALL accept `min_notional` as a parameter for filtering orders below the exchange minimum.
+
+#### Scenario: Basic invocation with all parameters
+- **WHEN** `compute_desired_orders` is called with a valid grid, boundary_level=5, effective_token=3.0, effective_usdc=100.0, order_sz=1.0, min_notional=0.0
+- **THEN** the function SHALL return a list of `DesiredOrder` objects with asks starting at level 5 ascending and bids starting at level 4 descending
+
+#### Scenario: Default min_notional
+- **WHEN** `compute_desired_orders` is called without specifying min_notional
+- **THEN** min_notional SHALL default to 0.0 (no filtering)
+
+## ADDED Requirements
+
+### Requirement: DesiredOrder dataclass
+The system SHALL define a `DesiredOrder` frozen dataclass with fields: `side` (str, "buy" or "sell"), `level_index` (int), `price` (float), and `size` (float). `DesiredOrder` SHALL be immutable and hashable.
+
+#### Scenario: DesiredOrder creation
+- **WHEN** a `DesiredOrder` is created with side="sell", level_index=5, price=1.003, size=10.0
+- **THEN** all fields SHALL be accessible and the object SHALL be immutable
+
+#### Scenario: DesiredOrder equality
+- **WHEN** two `DesiredOrder` objects are created with identical fields
+- **THEN** they SHALL be equal and have the same hash
+
+### Requirement: Ask-side order generation
+The function SHALL compute ask orders as follows:
+1. Compute `n_full = floor(effective_token / order_sz)`
+2. Place `n_full` asks of size `order_sz` at ascending grid levels starting from `boundary_level`
+3. Compute `partial = effective_token - n_full * order_sz`
+4. If `partial > 0`, place one partial ask at level `boundary_level + n_full`
+5. If any ask level exceeds the grid's maximum index, truncate (do not place that order)
+
+Each ask order SHALL have `side="sell"`, the grid level's price, and the appropriate size.
+
+#### Scenario: Three full asks and one partial
+- **WHEN** effective_token=3.5, order_sz=1.0, boundary_level=2
+- **THEN** the function SHALL produce asks at levels 2, 3, 4 (size 1.0 each) and level 5 (size 0.5)
+
+#### Scenario: Exact multiple of order_sz
+- **WHEN** effective_token=3.0, order_sz=1.0, boundary_level=2
+- **THEN** the function SHALL produce exactly 3 asks at levels 2, 3, 4 with no partial
+
+#### Scenario: Token balance less than one order_sz
+- **WHEN** effective_token=0.3, order_sz=1.0, boundary_level=2
+- **THEN** the function SHALL produce one partial ask at level 2 (size 0.3)
+
+#### Scenario: Grid overflow on ask side
+- **WHEN** boundary_level is near the top of the grid and n_full asks would exceed grid bounds
+- **THEN** asks SHALL be truncated at the grid's maximum level index
+
+### Requirement: Bid-side order generation
+The function SHALL compute bid orders by walking grid levels descending from `boundary_level - 1`:
+1. At each level, compute cost = `grid.price_at_level(level) * order_sz`
+2. If `effective_usdc >= cost`, place a full bid (size `order_sz`) and deduct cost
+3. If remaining USDC cannot cover a full bid but is > 0, place a partial bid with size `remaining_usdc / price`
+4. Stop when USDC is exhausted or level 0 is reached
+
+Each bid order SHALL have `side="buy"`, the grid level's price, and the appropriate size.
+
+#### Scenario: Two full bids and one partial
+- **WHEN** effective_usdc is enough for 2 full bids at levels below boundary with some remainder
+- **THEN** the function SHALL produce 2 full bids and 1 partial bid at descending levels
+
+#### Scenario: USDC exhausted before reaching level 0
+- **WHEN** effective_usdc covers fewer bids than levels available below the boundary
+- **THEN** the function SHALL stop placing bids when USDC is exhausted
+
+#### Scenario: Boundary at level 0
+- **WHEN** boundary_level=0
+- **THEN** there SHALL be no bid orders (no levels below boundary)
+
+### Requirement: Minimum notional filtering
+After computing all orders, the function SHALL remove any order where `price * size < min_notional`. This applies to both asks and bids, including partial orders.
+
+#### Scenario: Partial order below minimum notional
+- **WHEN** a partial ask has price=1.0, size=0.001, and min_notional=0.01
+- **THEN** that order SHALL be excluded from the result
+
+#### Scenario: All orders above minimum notional
+- **WHEN** all computed orders have notional >= min_notional
+- **THEN** all orders SHALL be included in the result
+
+### Requirement: Determinism
+The function SHALL be deterministic: given identical inputs, it SHALL always produce identical output in the same order. The function SHALL have no side effects, no I/O, and no dependency on external mutable state.
+
+#### Scenario: Repeated invocation
+- **WHEN** `compute_desired_orders` is called twice with the same arguments
+- **THEN** both calls SHALL return identical lists of DesiredOrder objects
+
+### Requirement: Empty and one-sided edge cases
+The function SHALL handle degenerate inventory states:
+- Zero token balance: return only bid orders
+- Zero USDC balance: return only ask orders
+- Both zero: return an empty list
+
+#### Scenario: All tokens sold
+- **WHEN** effective_token=0.0 and effective_usdc > 0
+- **THEN** the function SHALL return only buy orders
+
+#### Scenario: All USDC spent
+- **WHEN** effective_usdc=0.0 and effective_token > 0
+- **THEN** the function SHALL return only sell orders
+
+#### Scenario: Both balances zero
+- **WHEN** effective_token=0.0 and effective_usdc=0.0
+- **THEN** the function SHALL return an empty list
+
+### Requirement: No I/O module dependencies
+The quoting engine module SHALL NOT import or reference `order_state`, `ws_state`, `batch_emitter`, `rate_limit`, or any I/O modules. Its only dependency SHALL be `pricing_grid.PricingGrid`.
+
+#### Scenario: Module imports
+- **WHEN** the quoting_engine module is inspected
+- **THEN** it SHALL only import from `pricing_grid`, standard library, and typing modules

--- a/openspec/changes/implement-quoting-engine/tasks.md
+++ b/openspec/changes/implement-quoting-engine/tasks.md
@@ -1,0 +1,31 @@
+## 1. Core Data Structures
+
+- [x] 1.1 Define `DesiredOrder` frozen dataclass in `src/pyperliquidity/quoting_engine.py` with fields: side (str), level_index (int), price (float), size (float)
+
+## 2. Core Algorithm
+
+- [x] 2.1 Implement `compute_desired_orders()` function signature with parameters: grid, boundary_level, effective_token, effective_usdc, order_sz, min_notional
+- [x] 2.2 Implement ask-side order generation: n_full asks ascending from boundary_level, plus optional partial
+- [x] 2.3 Implement bid-side order generation: walk descending from boundary_level-1, full bids then partial, deducting USDC
+- [x] 2.4 Implement minimum notional filtering on combined order list
+- [x] 2.5 Handle grid overflow: truncate asks/bids that exceed grid bounds
+
+## 3. Edge Cases
+
+- [x] 3.1 Handle zero token balance (bids only)
+- [x] 3.2 Handle zero USDC balance (asks only)
+- [x] 3.3 Handle both balances zero (empty list)
+- [x] 3.4 Handle boundary_level at 0 (no bids) and at grid max (no asks)
+
+## 4. Tests
+
+- [x] 4.1 Test DesiredOrder dataclass: creation, immutability, equality, hashing
+- [x] 4.2 Test basic ask generation: exact multiples, partials, single partial
+- [x] 4.3 Test basic bid generation: full bids, partial at bottom, USDC exhaustion
+- [x] 4.4 Test combined ask+bid generation with typical inventory
+- [x] 4.5 Test empty/one-sided edge cases: zero tokens, zero USDC, both zero
+- [x] 4.6 Test minimum notional filtering: partial below threshold, all above, all below
+- [x] 4.7 Test grid overflow: asks truncated at grid max, boundary at 0
+- [x] 4.8 Test determinism: identical inputs produce identical outputs across repeated calls
+- [x] 4.9 Test boundary walk: simulate fill sequence moving boundary up and down the grid
+- [x] 4.10 Verify module has no forbidden imports (order_state, ws_state, batch_emitter, rate_limit)

--- a/src/pyperliquidity/quoting_engine.py
+++ b/src/pyperliquidity/quoting_engine.py
@@ -1,9 +1,17 @@
-"""Quoting engine — pure function: inventory + grid → desired orders."""
+"""Quoting engine — pure function: inventory + grid → desired orders.
+
+No I/O, no side effects. This is the HIP-2 algorithm: given a price grid,
+current balances, and boundary level, produce the deterministic set of
+desired resting orders.
+"""
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import Literal
+
+from pyperliquidity.pricing_grid import PricingGrid
 
 
 @dataclass(frozen=True, slots=True)
@@ -14,3 +22,88 @@ class DesiredOrder:
     level_index: int
     price: float
     size: float
+
+
+def compute_desired_orders(
+    grid: PricingGrid,
+    boundary_level: int,
+    effective_token: float,
+    effective_usdc: float,
+    order_sz: float,
+    min_notional: float = 0.0,
+) -> list[DesiredOrder]:
+    """Compute the desired set of resting orders from inventory state.
+
+    Parameters
+    ----------
+    grid : PricingGrid
+        The geometric price grid.
+    boundary_level : int
+        Grid index of the lowest ask level.  Asks are placed at
+        ``boundary_level`` and above; bids at ``boundary_level - 1`` and below.
+    effective_token : float
+        Effective token balance available for ask orders.
+    effective_usdc : float
+        Effective USDC balance available for bid orders.
+    order_sz : float
+        Size of a full order tranche.
+    min_notional : float
+        Minimum ``price * size`` for an order to be emitted.  Orders below
+        this threshold are filtered out.
+
+    Returns
+    -------
+    list[DesiredOrder]
+        Deterministic list of desired orders (asks then bids).
+    """
+    orders: list[DesiredOrder] = []
+
+    max_level = len(grid.levels) - 1
+
+    # --- Ask side: ascending from boundary_level ---
+    if effective_token > 0 and order_sz > 0:
+        n_full = math.floor(effective_token / order_sz)
+        partial = effective_token - n_full * order_sz
+        # Clamp tiny negatives from float arithmetic
+        if partial < 0:
+            partial = 0.0
+
+        for i in range(n_full):
+            lvl = boundary_level + i
+            if lvl > max_level:
+                break
+            px = grid.price_at_level(lvl)
+            orders.append(DesiredOrder(side="sell", level_index=lvl, price=px, size=order_sz))
+
+        if partial > 0:
+            partial_lvl = boundary_level + n_full
+            if partial_lvl <= max_level:
+                px = grid.price_at_level(partial_lvl)
+                orders.append(
+                    DesiredOrder(side="sell", level_index=partial_lvl, price=px, size=partial)
+                )
+
+    # --- Bid side: descending from boundary_level - 1 ---
+    if effective_usdc > 0 and order_sz > 0:
+        available = effective_usdc
+        for lvl in range(boundary_level - 1, -1, -1):
+            px = grid.price_at_level(lvl)
+            cost = px * order_sz
+            if available >= cost:
+                orders.append(
+                    DesiredOrder(side="buy", level_index=lvl, price=px, size=order_sz)
+                )
+                available -= cost
+            else:
+                if available > 0 and px > 0:
+                    partial_sz = available / px
+                    orders.append(
+                        DesiredOrder(side="buy", level_index=lvl, price=px, size=partial_sz)
+                    )
+                break
+
+    # --- Minimum notional filter ---
+    if min_notional > 0:
+        orders = [o for o in orders if o.price * o.size >= min_notional]
+
+    return orders

--- a/tests/test_quoting_engine.py
+++ b/tests/test_quoting_engine.py
@@ -1,0 +1,491 @@
+"""Tests for the quoting engine module."""
+
+from __future__ import annotations
+
+import ast
+import inspect
+
+import pytest
+
+from pyperliquidity.pricing_grid import PricingGrid
+from pyperliquidity.quoting_engine import DesiredOrder, compute_desired_orders
+
+# --- Shared fixtures ---
+
+
+@pytest.fixture()
+def grid() -> PricingGrid:
+    """A 20-level grid starting at 1.0 with default 0.3% spacing."""
+    return PricingGrid(start_px=1.0, n_orders=20)
+
+
+@pytest.fixture()
+def small_grid() -> PricingGrid:
+    """A 5-level grid for overflow testing."""
+    return PricingGrid(start_px=1.0, n_orders=5)
+
+
+# --- 4.1 DesiredOrder dataclass ---
+
+
+class TestDesiredOrder:
+    def test_creation(self) -> None:
+        o = DesiredOrder(side="sell", level_index=5, price=1.003, size=10.0)
+        assert o.side == "sell"
+        assert o.level_index == 5
+        assert o.price == 1.003
+        assert o.size == 10.0
+
+    def test_immutability(self) -> None:
+        o = DesiredOrder(side="buy", level_index=3, price=0.99, size=5.0)
+        with pytest.raises(AttributeError):
+            o.side = "sell"  # type: ignore[misc]
+        with pytest.raises(AttributeError):
+            o.price = 1.0  # type: ignore[misc]
+
+    def test_equality(self) -> None:
+        a = DesiredOrder(side="sell", level_index=5, price=1.003, size=10.0)
+        b = DesiredOrder(side="sell", level_index=5, price=1.003, size=10.0)
+        assert a == b
+
+    def test_inequality(self) -> None:
+        a = DesiredOrder(side="sell", level_index=5, price=1.003, size=10.0)
+        b = DesiredOrder(side="buy", level_index=5, price=1.003, size=10.0)
+        assert a != b
+
+    def test_hashing(self) -> None:
+        a = DesiredOrder(side="sell", level_index=5, price=1.003, size=10.0)
+        b = DesiredOrder(side="sell", level_index=5, price=1.003, size=10.0)
+        assert hash(a) == hash(b)
+        # Can be used in sets/dicts
+        s = {a, b}
+        assert len(s) == 1
+
+
+# --- 4.2 Basic ask generation ---
+
+
+class TestAskGeneration:
+    def test_exact_multiple(self, grid: PricingGrid) -> None:
+        orders = compute_desired_orders(
+            grid=grid, boundary_level=5, effective_token=3.0,
+            effective_usdc=0.0, order_sz=1.0,
+        )
+        asks = [o for o in orders if o.side == "sell"]
+        assert len(asks) == 3
+        assert all(a.size == 1.0 for a in asks)
+        assert [a.level_index for a in asks] == [5, 6, 7]
+
+    def test_partial_ask(self, grid: PricingGrid) -> None:
+        orders = compute_desired_orders(
+            grid=grid, boundary_level=5, effective_token=3.5,
+            effective_usdc=0.0, order_sz=1.0,
+        )
+        asks = [o for o in orders if o.side == "sell"]
+        assert len(asks) == 4
+        # First 3 are full
+        for a in asks[:3]:
+            assert a.size == 1.0
+        # Last is partial
+        assert abs(asks[3].size - 0.5) < 1e-10
+        assert [a.level_index for a in asks] == [5, 6, 7, 8]
+
+    def test_single_partial(self, grid: PricingGrid) -> None:
+        orders = compute_desired_orders(
+            grid=grid, boundary_level=2, effective_token=0.3,
+            effective_usdc=0.0, order_sz=1.0,
+        )
+        asks = [o for o in orders if o.side == "sell"]
+        assert len(asks) == 1
+        assert abs(asks[0].size - 0.3) < 1e-10
+        assert asks[0].level_index == 2
+
+    def test_ask_prices_match_grid(self, grid: PricingGrid) -> None:
+        orders = compute_desired_orders(
+            grid=grid, boundary_level=3, effective_token=2.0,
+            effective_usdc=0.0, order_sz=1.0,
+        )
+        asks = [o for o in orders if o.side == "sell"]
+        for a in asks:
+            assert a.price == grid.price_at_level(a.level_index)
+
+
+# --- 4.3 Basic bid generation ---
+
+
+class TestBidGeneration:
+    def test_full_bids(self, grid: PricingGrid) -> None:
+        # Give enough USDC for several full bids below boundary 5
+        # Levels 4, 3, 2, 1, 0 are available
+        usdc = sum(grid.price_at_level(i) * 1.0 for i in range(4, -1, -1))
+        orders = compute_desired_orders(
+            grid=grid, boundary_level=5, effective_token=0.0,
+            effective_usdc=usdc, order_sz=1.0,
+        )
+        bids = [o for o in orders if o.side == "buy"]
+        assert len(bids) == 5
+        assert all(b.size == 1.0 for b in bids)
+        # Descending level order
+        assert [b.level_index for b in bids] == [4, 3, 2, 1, 0]
+
+    def test_partial_bid_at_bottom(self, grid: PricingGrid) -> None:
+        # Give just enough for 2 full bids plus some remainder
+        cost_4 = grid.price_at_level(4) * 1.0
+        cost_3 = grid.price_at_level(3) * 1.0
+        extra = grid.price_at_level(2) * 0.5  # Half a bid at level 2
+        usdc = cost_4 + cost_3 + extra
+        orders = compute_desired_orders(
+            grid=grid, boundary_level=5, effective_token=0.0,
+            effective_usdc=usdc, order_sz=1.0,
+        )
+        bids = [o for o in orders if o.side == "buy"]
+        assert len(bids) == 3
+        assert bids[0].size == 1.0  # level 4
+        assert bids[1].size == 1.0  # level 3
+        assert abs(bids[2].size - 0.5) < 1e-6  # level 2 partial
+        assert bids[2].level_index == 2
+
+    def test_usdc_exhaustion(self, grid: PricingGrid) -> None:
+        # Very little USDC — only partial at first level
+        usdc = grid.price_at_level(4) * 0.1
+        orders = compute_desired_orders(
+            grid=grid, boundary_level=5, effective_token=0.0,
+            effective_usdc=usdc, order_sz=1.0,
+        )
+        bids = [o for o in orders if o.side == "buy"]
+        assert len(bids) == 1
+        assert bids[0].level_index == 4
+        assert abs(bids[0].size - 0.1) < 1e-6
+
+    def test_bid_prices_match_grid(self, grid: PricingGrid) -> None:
+        usdc = sum(grid.price_at_level(i) * 1.0 for i in range(3))
+        orders = compute_desired_orders(
+            grid=grid, boundary_level=4, effective_token=0.0,
+            effective_usdc=usdc, order_sz=1.0,
+        )
+        bids = [o for o in orders if o.side == "buy"]
+        for b in bids:
+            assert b.price == grid.price_at_level(b.level_index)
+
+
+# --- 4.4 Combined ask + bid generation ---
+
+
+class TestCombinedGeneration:
+    def test_typical_inventory(self, grid: PricingGrid) -> None:
+        orders = compute_desired_orders(
+            grid=grid, boundary_level=10, effective_token=3.0,
+            effective_usdc=50.0, order_sz=1.0,
+        )
+        asks = [o for o in orders if o.side == "sell"]
+        bids = [o for o in orders if o.side == "buy"]
+        assert len(asks) == 3
+        assert len(bids) > 0
+        # Asks start at boundary, ascending
+        assert asks[0].level_index == 10
+        # Bids start just below boundary, descending
+        assert bids[0].level_index == 9
+        # No overlap
+        ask_levels = {a.level_index for a in asks}
+        bid_levels = {b.level_index for b in bids}
+        assert ask_levels.isdisjoint(bid_levels)
+
+    def test_contiguous_orders(self, grid: PricingGrid) -> None:
+        """No gaps between highest bid and lowest ask."""
+        orders = compute_desired_orders(
+            grid=grid, boundary_level=10, effective_token=3.0,
+            effective_usdc=100.0, order_sz=1.0,
+        )
+        asks = sorted([o for o in orders if o.side == "sell"], key=lambda o: o.level_index)
+        bids = sorted(
+            [o for o in orders if o.side == "buy"], key=lambda o: o.level_index, reverse=True
+        )
+        if asks and bids:
+            lowest_ask = asks[0].level_index
+            highest_bid = bids[0].level_index
+            assert lowest_ask == highest_bid + 1
+
+    def test_total_ask_size_equals_token_balance(self, grid: PricingGrid) -> None:
+        token = 5.7
+        orders = compute_desired_orders(
+            grid=grid, boundary_level=5, effective_token=token,
+            effective_usdc=0.0, order_sz=1.0,
+        )
+        total_ask_sz = sum(o.size for o in orders if o.side == "sell")
+        assert abs(total_ask_sz - token) < 1e-10
+
+    def test_total_bid_cost_within_usdc(self, grid: PricingGrid) -> None:
+        usdc = 50.0
+        orders = compute_desired_orders(
+            grid=grid, boundary_level=10, effective_token=0.0,
+            effective_usdc=usdc, order_sz=1.0,
+        )
+        total_cost = sum(o.price * o.size for o in orders if o.side == "buy")
+        assert total_cost <= usdc + 1e-10
+
+
+# --- 4.5 Empty and one-sided edge cases ---
+
+
+class TestEdgeCases:
+    def test_zero_tokens_bids_only(self, grid: PricingGrid) -> None:
+        orders = compute_desired_orders(
+            grid=grid, boundary_level=10, effective_token=0.0,
+            effective_usdc=50.0, order_sz=1.0,
+        )
+        assert all(o.side == "buy" for o in orders)
+        assert len(orders) > 0
+
+    def test_zero_usdc_asks_only(self, grid: PricingGrid) -> None:
+        orders = compute_desired_orders(
+            grid=grid, boundary_level=5, effective_token=3.0,
+            effective_usdc=0.0, order_sz=1.0,
+        )
+        assert all(o.side == "sell" for o in orders)
+        assert len(orders) == 3
+
+    def test_both_zero_empty_list(self, grid: PricingGrid) -> None:
+        orders = compute_desired_orders(
+            grid=grid, boundary_level=5, effective_token=0.0,
+            effective_usdc=0.0, order_sz=1.0,
+        )
+        assert orders == []
+
+    def test_order_sz_larger_than_balance(self, grid: PricingGrid) -> None:
+        orders = compute_desired_orders(
+            grid=grid, boundary_level=5, effective_token=0.5,
+            effective_usdc=0.0, order_sz=10.0,
+        )
+        assert len(orders) == 1
+        assert orders[0].side == "sell"
+        assert abs(orders[0].size - 0.5) < 1e-10
+
+
+# --- 4.6 Minimum notional filtering ---
+
+
+class TestMinNotionalFiltering:
+    def test_partial_below_threshold(self, grid: PricingGrid) -> None:
+        orders = compute_desired_orders(
+            grid=grid, boundary_level=5, effective_token=1.001,
+            effective_usdc=0.0, order_sz=1.0, min_notional=0.01,
+        )
+        # The 0.001-size partial should be filtered (notional ~0.001)
+        asks = [o for o in orders if o.side == "sell"]
+        assert len(asks) == 1
+        assert asks[0].size == 1.0
+
+    def test_all_above_threshold(self, grid: PricingGrid) -> None:
+        orders = compute_desired_orders(
+            grid=grid, boundary_level=5, effective_token=3.0,
+            effective_usdc=50.0, order_sz=1.0, min_notional=0.01,
+        )
+        # All full orders should pass
+        assert len(orders) > 0
+        for o in orders:
+            assert o.price * o.size >= 0.01
+
+    def test_all_below_threshold(self, grid: PricingGrid) -> None:
+        orders = compute_desired_orders(
+            grid=grid, boundary_level=5, effective_token=0.001,
+            effective_usdc=0.001, order_sz=1.0, min_notional=10.0,
+        )
+        assert orders == []
+
+    def test_bid_partial_filtered(self, grid: PricingGrid) -> None:
+        # Give just a tiny bit of USDC, partial bid should be below min notional
+        usdc = 0.001
+        orders = compute_desired_orders(
+            grid=grid, boundary_level=5, effective_token=0.0,
+            effective_usdc=usdc, order_sz=1.0, min_notional=0.01,
+        )
+        assert orders == []
+
+
+# --- 4.7 Grid overflow ---
+
+
+class TestGridOverflow:
+    def test_asks_truncated_at_grid_max(self, small_grid: PricingGrid) -> None:
+        # 5-level grid (0-4), boundary at 3, 5 tokens → only 2 fit
+        orders = compute_desired_orders(
+            grid=small_grid, boundary_level=3, effective_token=5.0,
+            effective_usdc=0.0, order_sz=1.0,
+        )
+        asks = [o for o in orders if o.side == "sell"]
+        assert len(asks) == 2  # levels 3 and 4 only
+        assert [a.level_index for a in asks] == [3, 4]
+
+    def test_boundary_at_zero_no_bids(self, grid: PricingGrid) -> None:
+        orders = compute_desired_orders(
+            grid=grid, boundary_level=0, effective_token=3.0,
+            effective_usdc=100.0, order_sz=1.0,
+        )
+        bids = [o for o in orders if o.side == "buy"]
+        assert len(bids) == 0
+
+    def test_boundary_at_max_no_asks(self, grid: PricingGrid) -> None:
+        max_lvl = len(grid.levels) - 1
+        # boundary beyond max — no asks possible
+        orders = compute_desired_orders(
+            grid=grid, boundary_level=max_lvl + 1,
+            effective_token=3.0, effective_usdc=100.0, order_sz=1.0,
+        )
+        asks = [o for o in orders if o.side == "sell"]
+        assert len(asks) == 0
+
+    def test_partial_truncated_at_grid_max(self, small_grid: PricingGrid) -> None:
+        # Boundary at 4 (last level), 1.5 tokens → 1 full at 4, partial at 5 (overflow)
+        orders = compute_desired_orders(
+            grid=small_grid, boundary_level=4, effective_token=1.5,
+            effective_usdc=0.0, order_sz=1.0,
+        )
+        asks = [o for o in orders if o.side == "sell"]
+        assert len(asks) == 1  # Only the full at level 4
+        assert asks[0].level_index == 4
+        assert asks[0].size == 1.0
+
+
+# --- 4.8 Determinism ---
+
+
+class TestDeterminism:
+    def test_repeated_calls_identical(self, grid: PricingGrid) -> None:
+        kwargs = dict(
+            grid=grid, boundary_level=10, effective_token=5.5,
+            effective_usdc=80.0, order_sz=1.0, min_notional=0.01,
+        )
+        result1 = compute_desired_orders(**kwargs)
+        result2 = compute_desired_orders(**kwargs)
+        assert result1 == result2
+
+    def test_many_repeated_calls(self, grid: PricingGrid) -> None:
+        kwargs = dict(
+            grid=grid, boundary_level=7, effective_token=2.3,
+            effective_usdc=30.0, order_sz=0.5,
+        )
+        results = [compute_desired_orders(**kwargs) for _ in range(100)]
+        assert all(r == results[0] for r in results)
+
+
+# --- 4.9 Boundary walk: fill sequence ---
+
+
+class TestBoundaryWalk:
+    def test_fill_walks_boundary_up(self, grid: PricingGrid) -> None:
+        """Simulate selling tokens: boundary moves up the grid."""
+        order_sz = 1.0
+        total_token = 5.0
+        usdc = 0.0
+        boundary = 5
+
+        # Initial state
+        orders = compute_desired_orders(
+            grid=grid, boundary_level=boundary, effective_token=total_token,
+            effective_usdc=usdc, order_sz=order_sz,
+        )
+        assert orders[0].level_index == 5  # lowest ask at boundary
+
+        # Simulate selling 1 token (ask fill at boundary)
+        fill_px = grid.price_at_level(boundary)
+        total_token -= order_sz
+        usdc += fill_px * order_sz
+        boundary += 1  # boundary moves up
+
+        orders = compute_desired_orders(
+            grid=grid, boundary_level=boundary, effective_token=total_token,
+            effective_usdc=usdc, order_sz=order_sz,
+        )
+        asks = [o for o in orders if o.side == "sell"]
+        bids = [o for o in orders if o.side == "buy"]
+        assert asks[0].level_index == 6  # boundary shifted up
+        assert bids[0].level_index == 5  # old boundary is now a bid
+
+    def test_fill_walks_boundary_down(self, grid: PricingGrid) -> None:
+        """Simulate buying tokens: boundary moves down the grid."""
+        order_sz = 1.0
+        total_token = 0.0
+        boundary = 10
+        # Give enough USDC for several bids
+        usdc = sum(grid.price_at_level(i) * order_sz for i in range(boundary))
+
+        orders = compute_desired_orders(
+            grid=grid, boundary_level=boundary, effective_token=total_token,
+            effective_usdc=usdc, order_sz=order_sz,
+        )
+        bids = [o for o in orders if o.side == "buy"]
+        assert bids[0].level_index == 9  # highest bid
+
+        # Simulate buying 1 token (bid fill at level 9)
+        fill_px = grid.price_at_level(9)
+        total_token += order_sz
+        usdc -= fill_px * order_sz
+        boundary -= 1  # boundary moves down
+
+        orders = compute_desired_orders(
+            grid=grid, boundary_level=boundary, effective_token=total_token,
+            effective_usdc=usdc, order_sz=order_sz,
+        )
+        asks = [o for o in orders if o.side == "sell"]
+        bids = [o for o in orders if o.side == "buy"]
+        assert asks[0].level_index == 9  # old bid level is now lowest ask
+        assert bids[0].level_index == 8  # bids moved down
+
+    def test_round_trip(self, grid: PricingGrid) -> None:
+        """Sell then buy back — boundary returns to original position."""
+        order_sz = 1.0
+        token = 5.0
+        usdc = 0.0
+        boundary = 5
+
+        initial = compute_desired_orders(
+            grid=grid, boundary_level=boundary, effective_token=token,
+            effective_usdc=usdc, order_sz=order_sz,
+        )
+
+        # Sell one
+        px = grid.price_at_level(boundary)
+        token -= order_sz
+        usdc += px * order_sz
+        boundary += 1
+
+        # Buy it back (bid fill at boundary - 1 = original boundary)
+        px_buy = grid.price_at_level(boundary - 1)
+        token += order_sz
+        usdc -= px_buy * order_sz
+        boundary -= 1
+
+        final = compute_desired_orders(
+            grid=grid, boundary_level=boundary, effective_token=token,
+            effective_usdc=usdc, order_sz=order_sz,
+        )
+
+        # Same boundary, same token balance → same asks
+        initial_asks = [o for o in initial if o.side == "sell"]
+        final_asks = [o for o in final if o.side == "sell"]
+        assert initial_asks == final_asks
+
+
+# --- 4.10 No forbidden imports ---
+
+
+class TestModuleImports:
+    def test_no_forbidden_imports(self) -> None:
+        """The quoting_engine module must not import I/O modules."""
+        import pyperliquidity.quoting_engine as mod
+
+        source = inspect.getsource(mod)
+        tree = ast.parse(source)
+        forbidden = {"order_state", "ws_state", "batch_emitter", "rate_limit"}
+
+        imported_names: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    imported_names.add(alias.name.split(".")[-1])
+            elif isinstance(node, ast.ImportFrom):
+                if node.module:
+                    imported_names.add(node.module.split(".")[-1])
+
+        violations = imported_names & forbidden
+        assert not violations, f"Forbidden imports found: {violations}"


### PR DESCRIPTION
## Summary

- Implement `compute_desired_orders()` — the core HIP-2 algorithm as a pure, deterministic function with zero I/O
- Asks ascend from `boundary_level`, bids descend from `boundary_level - 1`, with partial orders and min notional filtering
- 35 pytest tests covering: dataclass behavior, ask/bid generation, edge cases (zero balances, grid overflow), determinism, boundary walk sequences, and forbidden import verification

## Test plan

- [x] All 35 new tests pass (`pytest tests/test_quoting_engine.py`)
- [x] Full suite passes (136 tests total)
- [x] Ruff lint clean
- [ ] Review boundary_level contract — caller passes it in, engine is stateless
- [ ] Verify DesiredOrder interface matches order_differ's expectations

🤖 Generated with [Claude Code](https://claude.com/claude-code)