### PR TITLE
Fix BatchEmitter wire-format KeyError on place/modify

### DIFF
--- a/src/pyperliquidity/batch_emitter.py
+++ b/src/pyperliquidity/batch_emitter.py
@@ -230,12 +230,12 @@ class BatchEmitter:
             {
                 "oid": oid,
                 "order": {
-                    "a": self.asset_id,
-                    "b": desired.side == "buy",
-                    "p": str(desired.price),
-                    "s": str(desired.size),
-                    "r": False,
-                    "t": _ALO_ORDER_TYPE,
+                    "coin": self.coin,
+                    "is_buy": desired.side == "buy",
+                    "sz": desired.size,
+                    "limit_px": desired.price,
+                    "order_type": _ALO_ORDER_TYPE,
+                    "reduce_only": False,
                 },
             }
             for oid, desired in modifies
@@ -290,12 +290,12 @@ class BatchEmitter:
     ) -> tuple[int, int]:
         reqs = [
             {
-                "a": self.asset_id,
-                "b": d.side == "buy",
-                "p": str(d.price),
-                "s": str(d.size),
-                "r": False,
-                "t": _ALO_ORDER_TYPE,
+                "coin": self.coin,
+                "is_buy": d.side == "buy",
+                "sz": d.size,
+                "limit_px": d.price,
+                "order_type": _ALO_ORDER_TYPE,
+                "reduce_only": False,
             }
             for d in places
         ]

--- a/tests/test_batch_emitter.py
+++ b/tests/test_batch_emitter.py
@@ -284,7 +284,7 @@ async def test_cooldown_suppresses_placements():
     assert result.n_placed == 1
     placed_reqs = ex.bulk_orders.call_args[0][0]
     assert len(placed_reqs) == 1
-    assert placed_reqs[0]["b"] is True  # buy
+    assert placed_reqs[0]["is_buy"] is True  # buy
 
 
 async def test_successful_placement_clears_cooldown():


### PR DESCRIPTION
## Summary
- `_execute_places` and `_execute_modifies` in `batch_emitter.py` were constructing wire-format dicts (`"a"`, `"b"`, `"p"`, `"s"`, `"r"`, `"t"`) but the SDK's `bulk_orders()` and `bulk_modify_orders_new()` expect high-level OrderRequest format (`"coin"`, `"is_buy"`, `"sz"`, `"limit_px"`, `"order_type"`, `"reduce_only"`) and convert to wire format internally
- Changed both methods to use the SDK's expected format, fixing `KeyError: 'coin'` on every place/modify call
- Cancel format (`{"a": asset_id, "o": oid}`) was already correct and left unchanged

Closes #15

## Test plan
- [x] All 237 existing tests pass
- [x] `ruff check` clean
- [x] `mypy` clean
- [ ] Manual test against Hyperliquid testnet to confirm orders place and modify successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)