### PR TITLE
Fix _execute_cancels KeyError: 'coin'

### DIFF
--- a/src/pyperliquidity/batch_emitter.py
+++ b/src/pyperliquidity/batch_emitter.py
@@ -208,7 +208,7 @@ class BatchEmitter:
         cancel_oids: list[int],
         budget: RateLimitBudget,
     ) -> tuple[int, int]:
-        reqs = [{"a": self.asset_id, "o": oid} for oid in cancel_oids]
+        reqs = [{"coin": self.coin, "o": oid} for oid in cancel_oids]
 
         try:
             response = await asyncio.to_thread(self._exchange.bulk_cancel, reqs)


### PR DESCRIPTION
## Summary
- `_execute_cancels` was constructing cancel requests in wire format (`{"a": asset_id, "o": oid}`) but the SDK's `bulk_cancel()` expects `{"coin": coin, "o": oid}`, causing a `KeyError: 'coin'` on every cancel attempt
- Changed to use `self.coin`, matching how `_execute_modifies` and `_execute_places` already work

Closes #22

## Test plan
- [x] All 250 existing tests pass
- [ ] Verify cancels execute without `KeyError` during live MM operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)