### PR TITLE
Fix dead zone suppressing structural changes after fills

### DIFF
--- a/src/pyperliquidity/order_differ.py
+++ b/src/pyperliquidity/order_differ.py
@@ -62,25 +62,29 @@ def compute_diff(
     if not desired:
         return OrderDiff(cancels=[t.oid for t in current])
 
-    # --- Step 1: Dead-zone check ---
-    desired_mid = _weighted_mid_price(
-        [d.price for d in desired], [d.size for d in desired]
-    )
-    current_mid = _weighted_mid_price(
-        [c.price for c in current], [c.size for c in current]
-    )
-    if current_mid > 0.0:
-        drift_bps = abs(desired_mid - current_mid) / current_mid * 10_000
-        if drift_bps < dead_zone_bps:
-            return _EMPTY
-
-    # --- Step 2: Level-index matching ---
+    # --- Step 1: Level-index matching (build maps first for structural check) ---
     desired_by_key: dict[tuple[str, int], DesiredOrder] = {
         (d.side, d.level_index): d for d in desired
     }
     current_by_key: dict[tuple[str, int], TrackedOrder] = {
         (c.side, c.level_index): c for c in current
     }
+
+    # --- Step 2: Dead-zone check (bypassed on structural changes) ---
+    # Structural changes (new levels, removed levels, side flips) always
+    # propagate — the dead zone only suppresses price/size drift when
+    # the same set of (side, level_index) keys is present on both sides.
+    if desired_by_key.keys() == current_by_key.keys():
+        desired_mid = _weighted_mid_price(
+            [d.price for d in desired], [d.size for d in desired]
+        )
+        current_mid = _weighted_mid_price(
+            [c.price for c in current], [c.size for c in current]
+        )
+        if current_mid > 0.0:
+            drift_bps = abs(desired_mid - current_mid) / current_mid * 10_000
+            if drift_bps < dead_zone_bps:
+                return _EMPTY
 
     modifies: list[tuple[int, DesiredOrder]] = []
     places: list[DesiredOrder] = []

--- a/tests/mock_exchange.py
+++ b/tests/mock_exchange.py
@@ -1,0 +1,185 @@
+"""Stateful mock exchange and info objects for integration tests.
+
+Provides MockExchange (order management with OID tracking) and MockInfo
+(REST endpoints) that are more realistic than MagicMock for multi-tick
+tests where order state must be consistent across calls.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class MockExchange:
+    """Stateful mock of the Hyperliquid SDK exchange object.
+
+    Tracks resting orders with auto-incrementing OIDs so that
+    multi-tick integration tests can verify order lifecycle end-to-end.
+    """
+
+    def __init__(self, starting_oid: int = 1000) -> None:
+        self._next_oid = starting_oid
+        # oid → {coin, is_buy, sz, limit_px, ...}
+        self.resting: dict[int, dict[str, Any]] = {}
+
+    def _alloc_oid(self) -> int:
+        oid = self._next_oid
+        self._next_oid += 1
+        return oid
+
+    # -- SDK-compatible batch methods ------------------------------------------
+
+    def bulk_orders(self, reqs: list[dict[str, Any]]) -> dict[str, Any]:
+        """Place orders. Returns SDK-format response with statuses."""
+        statuses: list[dict[str, Any]] = []
+        for req in reqs:
+            oid = self._alloc_oid()
+            self.resting[oid] = {
+                "coin": req["coin"],
+                "is_buy": req["is_buy"],
+                "sz": req["sz"],
+                "limit_px": req["limit_px"],
+            }
+            statuses.append({"resting": {"oid": oid}})
+        return {"status": "ok", "response": {"data": {"statuses": statuses}}}
+
+    def bulk_modify_orders_new(self, reqs: list[dict[str, Any]]) -> dict[str, Any]:
+        """Modify orders. Assigns new OIDs (mirrors real exchange behavior)."""
+        statuses: list[dict[str, Any]] = []
+        for req in reqs:
+            old_oid = req["oid"]
+            order_spec = req["order"]
+            if old_oid not in self.resting:
+                statuses.append({"error": "Cannot modify order"})
+                continue
+            # Remove old, insert new with fresh OID
+            del self.resting[old_oid]
+            new_oid = self._alloc_oid()
+            self.resting[new_oid] = {
+                "coin": order_spec["coin"],
+                "is_buy": order_spec["is_buy"],
+                "sz": order_spec["sz"],
+                "limit_px": order_spec["limit_px"],
+            }
+            statuses.append({"resting": {"oid": new_oid}})
+        return {"status": "ok", "response": {"data": {"statuses": statuses}}}
+
+    def bulk_cancel(self, reqs: list[dict[str, Any]]) -> dict[str, Any]:
+        """Cancel orders by OID."""
+        statuses: list[dict[str, Any]] = []
+        for req in reqs:
+            oid = req["o"]
+            if oid in self.resting:
+                del self.resting[oid]
+                statuses.append({"success": True})
+            else:
+                statuses.append({"error": "Order not found"})
+        return {"status": "ok", "response": {"data": {"statuses": statuses}}}
+
+    # -- Test helpers ----------------------------------------------------------
+
+    def fill_order(
+        self, oid: int, fill_sz: float | None = None, tid: int = 0,
+    ) -> dict[str, Any]:
+        """Simulate a fill. Returns a fill event dict for _handle_fill().
+
+        If *fill_sz* is None, the entire order is filled.
+        """
+        order = self.resting.get(oid)
+        if order is None:
+            raise KeyError(f"OID {oid} not resting")
+
+        sz = fill_sz if fill_sz is not None else order["sz"]
+        px = order["limit_px"]
+        side = "B" if order["is_buy"] else "A"
+
+        remaining = order["sz"] - sz
+        if remaining <= 1e-12:
+            del self.resting[oid]
+        else:
+            order["sz"] = remaining
+
+        return {
+            "tid": tid,
+            "oid": oid,
+            "sz": str(sz),
+            "px": str(px),
+            "side": side,
+        }
+
+    def open_orders_list(self, coin: str) -> list[dict[str, Any]]:
+        """Return open_orders in SDK REST format for a given coin."""
+        result = []
+        for oid, o in self.resting.items():
+            if o["coin"] == coin:
+                result.append({
+                    "coin": coin,
+                    "oid": oid,
+                    "side": "B" if o["is_buy"] else "A",
+                    "limitPx": str(o["limit_px"]),
+                    "sz": str(o["sz"]),
+                })
+        return result
+
+
+class MockInfo:
+    """Stateful mock of the Hyperliquid SDK info object.
+
+    Delegates open_orders to MockExchange for consistency.
+    """
+
+    def __init__(
+        self,
+        mock_exchange: MockExchange,
+        coin: str = "TEST",
+        spot_index: int = 5,
+        base_token_name: str = "TESTBASE",
+        token_bal: float = 100.0,
+        usdc_bal: float = 500.0,
+        cum_vlm: float = 1000.0,
+        n_requests: int = 200,
+    ) -> None:
+        self._exchange = mock_exchange
+        self.coin = coin
+        self._spot_index = spot_index
+        self._base_token_name = base_token_name
+        self.token_bal = token_bal
+        self.usdc_bal = usdc_bal
+        self._cum_vlm = cum_vlm
+        self._n_requests = n_requests
+
+    def spot_meta(self) -> dict[str, Any]:
+        base_token_idx = 0
+        universe = [
+            {"name": f"COIN{i}", "index": i, "tokens": [i + 1]}
+            for i in range(self._spot_index)
+        ]
+        universe.append({
+            "name": self.coin,
+            "index": self._spot_index,
+            "tokens": [base_token_idx],
+        })
+        return {
+            "universe": universe,
+            "tokens": [{"name": self._base_token_name}],
+        }
+
+    def open_orders(self, addr: str) -> list[dict[str, Any]]:
+        return self._exchange.open_orders_list(self.coin)
+
+    def spot_user_state(self, addr: str) -> dict[str, Any]:
+        return {
+            "balances": [
+                {"coin": self._base_token_name, "total": str(self.token_bal)},
+                {"coin": "USDC", "total": str(self.usdc_bal)},
+            ],
+        }
+
+    def user_rate_limit(self, addr: str) -> dict[str, Any]:
+        return {
+            "cumVlm": str(self._cum_vlm),
+            "nRequestsUsed": str(self._n_requests),
+        }
+
+    def subscribe(self, sub: dict[str, Any], cb: Any) -> None:
+        pass  # no-op

--- a/tests/test_fill_coverage.py
+++ b/tests/test_fill_coverage.py
@@ -1,0 +1,202 @@
+"""Integration tests: verify all n_orders levels stay covered after fills.
+
+Uses MockExchange/MockInfo for realistic multi-tick simulation of the
+fill → boundary shift → requote → emit pipeline.
+"""
+
+from __future__ import annotations
+
+from pyperliquidity.ws_state import WsState
+from tests.mock_exchange import MockExchange, MockInfo
+
+# --- Config -------------------------------------------------------------------
+
+N_ORDERS = 20
+N_SEEDED = 10
+ORDER_SZ = 10.0
+START_PX = 1.0
+TOKEN_BAL = 10_000.0  # generous — never balance-limited
+USDC_BAL = 100_000.0
+
+
+# --- Helpers ------------------------------------------------------------------
+
+def _make_system() -> tuple[WsState, MockExchange, MockInfo]:
+    """Build a WsState wired to MockExchange/MockInfo."""
+    ex = MockExchange()
+    info = MockInfo(
+        mock_exchange=ex,
+        coin="TEST",
+        spot_index=5,
+        token_bal=TOKEN_BAL,
+        usdc_bal=USDC_BAL,
+    )
+    ws = WsState(
+        coin="TEST",
+        start_px=START_PX,
+        n_orders=N_ORDERS,
+        order_sz=ORDER_SZ,
+        n_seeded_levels=N_SEEDED,
+        info=info,
+        exchange=ex,
+        address="0xtest",
+        interval_s=3.0,
+        dead_zone_bps=5.0,
+        price_tolerance_bps=1.0,
+        size_tolerance_pct=1.0,
+        reconcile_every=100,
+    )
+    return ws, ex, info
+
+
+def _assert_full_coverage(ws: WsState, n_orders: int) -> None:
+    """Assert every level 0..n_orders-1 has exactly one order in order_state."""
+    covered_levels: dict[int, str] = {}
+    for o in ws.order_state.orders_by_oid.values():
+        assert o.level_index not in covered_levels, (
+            f"Duplicate order at level {o.level_index}: "
+            f"side={o.side} vs {covered_levels[o.level_index]}"
+        )
+        covered_levels[o.level_index] = o.side
+
+    total = len(covered_levels)
+    assert total == n_orders, (
+        f"Expected {n_orders} covered levels, got {total}. "
+        f"Missing: {set(range(n_orders)) - set(covered_levels.keys())}"
+    )
+
+    # Verify structural consistency: asks at boundary and above, bids below
+    for lvl, side in covered_levels.items():
+        if lvl >= ws.boundary_level:
+            assert side == "sell", (
+                f"Level {lvl} >= boundary {ws.boundary_level} should be sell, got {side}"
+            )
+        else:
+            assert side == "buy", (
+                f"Level {lvl} < boundary {ws.boundary_level} should be buy, got {side}"
+            )
+
+
+async def _startup_and_initial_tick(ws: WsState) -> None:
+    """Run startup and one tick to place initial orders."""
+    await ws._startup()
+    await ws._tick()
+
+
+def _find_oid_at_level(ws: WsState, level: int) -> int:
+    """Find the OID of the order at a given level."""
+    for o in ws.order_state.orders_by_oid.values():
+        if o.level_index == level:
+            return o.oid
+    raise ValueError(f"No order at level {level}")
+
+
+async def _fill_boundary_ask(
+    ws: WsState, ex: MockExchange, tid: int,
+) -> None:
+    """Fill the ask at the current boundary level and process it."""
+    oid = _find_oid_at_level(ws, ws.boundary_level)
+    fill_event = ex.fill_order(oid, tid=tid)
+    await ws._handle_fill({"user": "0xtest", "fills": [fill_event]})
+
+
+async def _fill_boundary_bid(
+    ws: WsState, ex: MockExchange, tid: int,
+) -> None:
+    """Fill the bid at boundary_level - 1 and process it."""
+    bid_level = ws.boundary_level - 1
+    oid = _find_oid_at_level(ws, bid_level)
+    fill_event = ex.fill_order(oid, tid=tid)
+    await ws._handle_fill({"user": "0xtest", "fills": [fill_event]})
+
+
+# --- Tests --------------------------------------------------------------------
+
+async def test_single_ask_fill_maintains_coverage():
+    """Fill 1 ask at boundary → 20 orders remain after requote."""
+    ws, ex, info = _make_system()
+    await _startup_and_initial_tick(ws)
+    _assert_full_coverage(ws, N_ORDERS)
+
+    # Fill the ask at the boundary
+    await _fill_boundary_ask(ws, ex, tid=1)
+    # Tick to requote
+    await ws._tick()
+    _assert_full_coverage(ws, N_ORDERS)
+
+
+async def test_sequential_ask_fills_walk_boundary_up():
+    """Fill 5 asks sequentially → coverage maintained at each step."""
+    ws, ex, info = _make_system()
+    await _startup_and_initial_tick(ws)
+    _assert_full_coverage(ws, N_ORDERS)
+
+    for i in range(5):
+        await _fill_boundary_ask(ws, ex, tid=100 + i)
+        await ws._tick()
+        _assert_full_coverage(ws, N_ORDERS)
+
+
+async def test_sequential_bid_fills_walk_boundary_down():
+    """Fill 5 bids sequentially → coverage maintained at each step."""
+    ws, ex, info = _make_system()
+    await _startup_and_initial_tick(ws)
+    _assert_full_coverage(ws, N_ORDERS)
+
+    for i in range(5):
+        await _fill_boundary_bid(ws, ex, tid=200 + i)
+        await ws._tick()
+        _assert_full_coverage(ws, N_ORDERS)
+
+
+async def test_round_trip_coverage():
+    """Walk 3 up (ask fills), then 3 down (bid fills) → coverage at every step."""
+    ws, ex, info = _make_system()
+    await _startup_and_initial_tick(ws)
+    _assert_full_coverage(ws, N_ORDERS)
+
+    # Walk up 3
+    for i in range(3):
+        await _fill_boundary_ask(ws, ex, tid=300 + i)
+        await ws._tick()
+        _assert_full_coverage(ws, N_ORDERS)
+
+    # Walk down 3
+    for i in range(3):
+        await _fill_boundary_bid(ws, ex, tid=400 + i)
+        await ws._tick()
+        _assert_full_coverage(ws, N_ORDERS)
+
+
+async def test_all_asks_filled_becomes_all_bids():
+    """Fill all asks → boundary=n_orders, all orders are bids."""
+    ws, ex, info = _make_system()
+    await _startup_and_initial_tick(ws)
+
+    n_asks = N_ORDERS - N_SEEDED  # 10 asks initially
+    for i in range(n_asks):
+        await _fill_boundary_ask(ws, ex, tid=500 + i)
+        await ws._tick()
+
+    assert ws.boundary_level == N_ORDERS
+    # All orders should be bids
+    for o in ws.order_state.orders_by_oid.values():
+        assert o.side == "buy", f"Expected all bids, got {o.side} at level {o.level_index}"
+    assert len(ws.order_state.orders_by_oid) == N_ORDERS
+
+
+async def test_all_bids_filled_becomes_all_asks():
+    """Fill all bids → boundary=0, all orders are asks."""
+    ws, ex, info = _make_system()
+    await _startup_and_initial_tick(ws)
+
+    n_bids = N_SEEDED  # 10 bids initially
+    for i in range(n_bids):
+        await _fill_boundary_bid(ws, ex, tid=600 + i)
+        await ws._tick()
+
+    assert ws.boundary_level == 0
+    # All orders should be asks
+    for o in ws.order_state.orders_by_oid.values():
+        assert o.side == "sell", f"Expected all asks, got {o.side} at level {o.level_index}"
+    assert len(ws.order_state.orders_by_oid) == N_ORDERS

--- a/tests/test_order_differ.py
+++ b/tests/test_order_differ.py
@@ -64,6 +64,33 @@ class TestDeadZone:
         assert len(diff.modifies) == 1
         assert diff.modifies[0] == (1, desired[0])
 
+    def test_structural_change_bypasses_dead_zone(self):
+        """When keys differ (fill removed a level, new level added), dead zone
+        is bypassed even if price drift is negligible."""
+        # 19 current orders: levels 0-9 bids, levels 11-19 asks (level 10 filled)
+        current = []
+        for i in range(10):
+            current.append(_tracked(i + 1, "buy", i, 100.0 - i * 0.3, 10.0))
+        for i in range(11, 20):
+            current.append(_tracked(i + 1, "sell", i, 100.0 + i * 0.3, 10.0))
+
+        # 20 desired orders: levels 0-9 bids (including new bid at 10), levels 11-19 asks
+        # Level 10 now a bid (the filled ask flipped to bid side)
+        desired = []
+        for i in range(11):  # bids at 0-10
+            desired.append(_desired("buy", i, 100.0 - i * 0.3, 10.0))
+        for i in range(11, 20):  # asks at 11-19
+            desired.append(_desired("sell", i, 100.0 + i * 0.3, 10.0))
+
+        # Use a very generous dead zone — should be bypassed due to structural change
+        diff = compute_diff(desired, current, dead_zone_bps=100.0,
+                            price_tolerance_bps=1.0, size_tolerance_pct=5.0)
+
+        # The diff must NOT be empty — it should place the new bid at level 10
+        assert diff != OrderDiff()
+        placed_levels = {p.level_index for p in diff.places}
+        assert 10 in placed_levels
+
 
 # ---------------------------------------------------------------------------
 # 3.3  Dead zone bypass: empty lists


### PR DESCRIPTION
## Summary

Fixes #23 — after fills at the boundary, grid levels go uncovered because the order differ's dead zone suppresses structural changes.

- **Root cause**: After a boundary fill, the desired orders include a new bid at the filled level that current orders don't have. But the weighted mid-price barely shifts (~1 bps), well below the `dead_zone_bps=5.0` threshold, so the dead zone returns `_EMPTY` and the new order is never placed.
- **Fix**: Move level-index map construction before the dead zone check. When `desired_by_key.keys() != current_by_key.keys()` (structural change — new level, removed level, or side flip), bypass the dead zone entirely. When keys match, the dead zone works as before to suppress unnecessary API churn.
- **New tests**: 6 integration tests using a stateful `MockExchange` verify full grid coverage is maintained after single fills, sequential walks up/down, round trips, and edge cases (all asks filled, all bids filled).

## Test plan

- [x] `test_structural_change_bypasses_dead_zone` — unit test confirming dead zone bypass on key mismatch
- [x] `test_single_ask_fill_maintains_coverage` — fill 1 ask → 20 orders remain
- [x] `test_sequential_ask_fills_walk_boundary_up` — fill 5 asks sequentially → coverage at each step
- [x] `test_sequential_bid_fills_walk_boundary_down` — fill 5 bids sequentially → coverage at each step
- [x] `test_round_trip_coverage` — walk 3 up, 3 down → coverage at every step
- [x] `test_all_asks_filled_becomes_all_bids` / `test_all_bids_filled_becomes_all_asks` — edge cases
- [x] All 257 existing tests pass, ruff clean, mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)