### PR TITLE
Rewrite inventory: virtual isolated balances + inventory-derived pricing

### DIFF
--- a/src/pyperliquidity/inventory.py
+++ b/src/pyperliquidity/inventory.py
@@ -1,31 +1,36 @@
-"""Token and USDC balance tracking with allocation-aware effective balances."""
+"""Token and USDC balance tracking with isolated virtual balances."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 @dataclass
 class Inventory:
-    """Allocation-aware balance tracker for HIP-2 market making.
+    """Isolated virtual balance tracker for HIP-2 market making.
 
-    Maintains three balance layers per asset:
-    - *allocated*: operator-configured ceiling
-    - *account*: actual exchange balance
-    - *effective*: ``min(allocated, account)`` — the only value quoting uses
+    Maintains four balance layers per asset:
+    - *allocated*: operator-configured starting balance (also the ceiling)
+    - *virtual*: isolated running balance, starts at allocation, adjusted by fills only
+    - *account*: actual exchange balance (hard safety cap)
+    - *effective*: ``min(virtual, account)`` — the only value quoting uses
+
+    Virtual balances track the strategy's isolated inventory independent of
+    the account-wide balance.  This allows multiple strategies to share a
+    single exchange wallet without interfering with each other's pricing.
 
     Parameters
     ----------
     order_sz : float
         Size of a full order tranche (HIP-2 parameter).
     allocated_token : float
-        Maximum token balance the strategy may use.
+        Initial token balance for this strategy (also the ceiling).
     allocated_usdc : float
-        Maximum USDC balance the strategy may use.
+        Initial USDC balance for this strategy (also the ceiling).
     account_token : float
-        Current token holdings on the exchange.
+        Current token holdings on the exchange (safety cap).
     account_usdc : float
-        Current USDC holdings on the exchange.
+        Current USDC holdings on the exchange (safety cap).
     """
 
     order_sz: float
@@ -34,44 +39,87 @@ class Inventory:
     account_token: float
     account_usdc: float
 
+    # Virtual balances — isolated, fill-driven.  Initialized from allocation.
+    virtual_token: float = field(init=False, default=0.0)
+    virtual_usdc: float = field(init=False, default=0.0)
+
     # Effective balances — set by __post_init__ and _recompute_effective
-    effective_token: float = 0.0
-    effective_usdc: float = 0.0
+    effective_token: float = field(init=False, default=0.0)
+    effective_usdc: float = field(init=False, default=0.0)
 
     def __post_init__(self) -> None:
+        self.virtual_token = self.allocated_token
+        self.virtual_usdc = self.allocated_usdc
         self._recompute_effective()
 
     # -- Private helpers ------------------------------------------------------
 
     def _recompute_effective(self) -> None:
-        """Set effective = min(allocated, account) for both assets."""
-        self.effective_token = min(self.allocated_token, self.account_token)
-        self.effective_usdc = min(self.allocated_usdc, self.account_usdc)
+        """Set effective = min(virtual, account) for both assets.
+
+        Virtual tracks the isolated inventory; account is a hard safety cap
+        to prevent placing orders that exceed actual exchange holdings.
+        """
+        self.effective_token = min(self.virtual_token, self.account_token)
+        self.effective_usdc = min(self.virtual_usdc, self.account_usdc)
 
     # -- Allocation management ------------------------------------------------
 
     def update_allocation(self, token: float, usdc: float) -> None:
-        """Update allocation ceilings and recompute effective balances."""
+        """Update allocation ceilings and recompute effective balances.
+
+        Adjusts virtual balances proportionally: the delta between old and new
+        allocation is applied to virtual balances.
+        """
+        token_delta = token - self.allocated_token
+        usdc_delta = usdc - self.allocated_usdc
         self.allocated_token = token
         self.allocated_usdc = usdc
+        self.virtual_token += token_delta
+        self.virtual_usdc += usdc_delta
         self._recompute_effective()
 
     # -- Event handlers -------------------------------------------------------
 
-    def on_ask_fill(self, px: float, sz: float) -> None:
-        """Process an ask-side fill: sold *sz* tokens at price *px*."""
-        self.account_token -= sz
-        self.account_usdc += px * sz
+    def on_ask_fill(
+        self, px: float, sz: float, fee: float = 0.0, fee_token: str = "USDC",
+    ) -> None:
+        """Process an ask-side fill: sold *sz* tokens at price *px*.
+
+        Adjusts virtual balances (the isolated inventory).  Account balances
+        are updated separately via ``on_balance_update``.
+        """
+        self.virtual_token -= sz
+        if fee_token == "USDC":
+            self.virtual_usdc += px * sz - fee
+        else:
+            self.virtual_usdc += px * sz
+            self.virtual_token -= fee
         self._recompute_effective()
 
-    def on_bid_fill(self, px: float, sz: float) -> None:
-        """Process a bid-side fill: bought *sz* tokens at price *px*."""
-        self.account_token += sz
-        self.account_usdc -= px * sz
+    def on_bid_fill(
+        self, px: float, sz: float, fee: float = 0.0, fee_token: str = "USDC",
+    ) -> None:
+        """Process a bid-side fill: bought *sz* tokens at price *px*.
+
+        Adjusts virtual balances (the isolated inventory).  Account balances
+        are updated separately via ``on_balance_update``.
+        """
+        self.virtual_usdc -= px * sz
+        if fee_token == "USDC":
+            self.virtual_usdc -= fee
+            self.virtual_token += sz
+        else:
+            self.virtual_token += sz - fee
         self._recompute_effective()
 
     def on_balance_update(self, token: float, usdc: float) -> None:
-        """Authoritative balance reset from exchange reconciliation."""
+        """Update account-wide balances (hard safety cap).
+
+        This does NOT reset virtual balances.  Virtual balances are only
+        adjusted by fills.  Account balances serve as a safety cap to
+        prevent placing orders that exceed actual exchange holdings.
+        """
         self.account_token = token
         self.account_usdc = usdc
         self._recompute_effective()

--- a/src/pyperliquidity/ws_state.py
+++ b/src/pyperliquidity/ws_state.py
@@ -293,6 +293,8 @@ class WsState:
             oid = fill.get("oid")
             sz = float(fill.get("sz", 0))
             px = float(fill.get("px", 0))
+            fee = float(fill.get("fee", 0))
+            fee_token = fill.get("feeToken", "USDC")
             if tid is None or oid is None:
                 continue
 
@@ -301,9 +303,13 @@ class WsState:
                 volume_usd = px * sz
                 self.rate_limit.on_fill(volume_usd)
                 if result.side == "sell":
-                    self.inventory.on_ask_fill(px=px, sz=sz)
+                    self.inventory.on_ask_fill(
+                        px=px, sz=sz, fee=fee, fee_token=fee_token,
+                    )
                 else:
-                    self.inventory.on_bid_fill(px=px, sz=sz)
+                    self.inventory.on_bid_fill(
+                        px=px, sz=sz, fee=fee, fee_token=fee_token,
+                    )
 
     async def _handle_balance_update(self, msg: Any) -> None:
         """Route webData2 balance updates to Inventory."""

--- a/tests/test_fill_coverage.py
+++ b/tests/test_fill_coverage.py
@@ -41,6 +41,8 @@ def _make_system() -> tuple[WsState, MockExchange, MockInfo]:
         price_tolerance_bps=1.0,
         size_tolerance_pct=1.0,
         reconcile_every=100,
+        allocated_token=TOKEN_BAL,
+        allocated_usdc=USDC_BAL,
     )
     return ws, ex, info
 

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -1,4 +1,4 @@
-"""Tests for the Inventory module."""
+"""Tests for the Inventory module — virtual isolated balances."""
 
 from __future__ import annotations
 
@@ -27,189 +27,294 @@ def _make_inv(
 
 
 # ===========================================================================
-# 1. Data Structures & Effective Balance Invariant
+# 1. Virtual Balance Initialization
 # ===========================================================================
 
 
-class TestEffectiveBalance:
-    def test_account_exceeds_allocation(self) -> None:
-        inv = _make_inv(acct_token=150.0, alloc_token=100.0)
-        assert inv.effective_token == 100.0
+class TestVirtualBalanceInit:
+    def test_virtual_starts_at_allocation(self) -> None:
+        inv = _make_inv(alloc_token=50.0, alloc_usdc=1250.0)
+        assert inv.virtual_token == 50.0
+        assert inv.virtual_usdc == 1250.0
 
-    def test_account_below_allocation(self) -> None:
-        inv = _make_inv(acct_token=80.0, alloc_token=100.0)
-        assert inv.effective_token == 80.0
-
-    def test_account_equals_allocation(self) -> None:
-        inv = _make_inv(acct_token=100.0, alloc_token=100.0)
-        assert inv.effective_token == 100.0
-
-    def test_zero_account(self) -> None:
-        inv = _make_inv(acct_token=0.0, alloc_token=100.0)
-        assert inv.effective_token == 0.0
-
-    def test_usdc_effective(self) -> None:
-        inv = _make_inv(acct_usdc=50.0, alloc_usdc=80.0)
-        assert inv.effective_usdc == 50.0
-
-    def test_usdc_capped_by_allocation(self) -> None:
-        inv = _make_inv(acct_usdc=200.0, alloc_usdc=80.0)
-        assert inv.effective_usdc == 80.0
-
-
-# ===========================================================================
-# 2. Allocation Management
-# ===========================================================================
-
-
-class TestAllocationUpdate:
-    def test_decrease_below_account(self) -> None:
-        inv = _make_inv(acct_token=100.0, alloc_token=150.0)
-        assert inv.effective_token == 100.0
-        inv.update_allocation(token=80.0, usdc=inv.allocated_usdc)
-        assert inv.allocated_token == 80.0
-        assert inv.effective_token == 80.0
-
-    def test_increase_above_account(self) -> None:
-        inv = _make_inv(acct_token=100.0, alloc_token=80.0)
-        assert inv.effective_token == 80.0
-        inv.update_allocation(token=150.0, usdc=inv.allocated_usdc)
-        assert inv.allocated_token == 150.0
-        assert inv.effective_token == 100.0  # still capped by account
-
-    def test_equal_to_account(self) -> None:
-        inv = _make_inv(acct_token=100.0, alloc_token=50.0)
-        inv.update_allocation(token=100.0, usdc=inv.allocated_usdc)
-        assert inv.effective_token == 100.0
-
-    def test_usdc_allocation_update(self) -> None:
-        inv = _make_inv(acct_usdc=100.0, alloc_usdc=200.0)
-        inv.update_allocation(token=inv.allocated_token, usdc=60.0)
-        assert inv.effective_usdc == 60.0
-
-
-# ===========================================================================
-# 3. Fill Event Handlers
-# ===========================================================================
-
-
-class TestFillEvents:
-    def test_ask_fill_basic(self) -> None:
-        inv = _make_inv(acct_token=100.0, alloc_token=100.0, acct_usdc=0.0, alloc_usdc=200.0)
-        inv.on_ask_fill(px=1.5, sz=10.0)
-        assert inv.account_token == pytest.approx(90.0)
-        assert inv.account_usdc == pytest.approx(15.0)
-        assert inv.effective_token == pytest.approx(90.0)
-        assert inv.effective_usdc == pytest.approx(15.0)
-
-    def test_bid_fill_basic(self) -> None:
-        inv = _make_inv(acct_token=0.0, alloc_token=200.0, acct_usdc=100.0, alloc_usdc=100.0)
-        inv.on_bid_fill(px=1.5, sz=10.0)
-        assert inv.account_token == pytest.approx(10.0)
-        assert inv.account_usdc == pytest.approx(85.0)
-        assert inv.effective_token == pytest.approx(10.0)
-        assert inv.effective_usdc == pytest.approx(85.0)
-
-    def test_fill_pushes_account_above_allocation(self) -> None:
-        inv = _make_inv(acct_token=95.0, alloc_token=100.0, acct_usdc=200.0, alloc_usdc=200.0)
-        inv.on_bid_fill(px=1.0, sz=10.0)
-        assert inv.account_token == pytest.approx(105.0)
-        assert inv.effective_token == pytest.approx(100.0)  # clamped
-
-    def test_fill_sequence(self) -> None:
+    def test_effective_is_min_virtual_account(self) -> None:
+        """When account >> allocation, effective = virtual (= allocation)."""
         inv = _make_inv(
-            order_sz=10.0,
-            acct_token=50.0, alloc_token=50.0,
-            acct_usdc=50.0, alloc_usdc=50.0,
+            alloc_token=5.0, alloc_usdc=1250.0,
+            acct_token=81.0, acct_usdc=489_000.0,
         )
+        assert inv.effective_token == 5.0
+        assert inv.effective_usdc == 1250.0
 
-        # Sell 20 tokens (2 ask fills)
-        inv.on_ask_fill(px=1.05, sz=10.0)
-        inv.on_ask_fill(px=1.06, sz=10.0)
-
-        assert inv.effective_token == pytest.approx(30.0)
-        # account_usdc increased but effective is capped by allocation
-        assert inv.account_usdc > 50.0
-        assert inv.effective_usdc == 50.0  # clamped to allocation
+    def test_effective_capped_by_account_when_account_lower(self) -> None:
+        inv = _make_inv(
+            alloc_token=100.0, alloc_usdc=1000.0,
+            acct_token=30.0, acct_usdc=500.0,
+        )
+        assert inv.effective_token == 30.0
+        assert inv.effective_usdc == 500.0
 
 
 # ===========================================================================
-# 4. Balance Reconciliation
+# 2. Fills Move Virtual Balances (Core Fix)
+# ===========================================================================
+
+
+class TestFillsMovePricing:
+    def test_ask_fill_moves_mid(self) -> None:
+        """The whole point: fills must change effective balances → mid moves."""
+        inv = _make_inv(
+            alloc_token=5.0, alloc_usdc=1250.0,
+            acct_token=81.0, acct_usdc=489_000.0,
+        )
+        mid_before = inv.effective_usdc / inv.effective_token  # 250.0
+        inv.on_ask_fill(px=250.75, sz=1.0)
+        mid_after = inv.effective_usdc / inv.effective_token
+        assert mid_after > mid_before  # sold tokens → more USDC, less token → higher mid
+
+    def test_bid_fill_moves_mid(self) -> None:
+        inv = _make_inv(
+            alloc_token=5.0, alloc_usdc=1250.0,
+            acct_token=81.0, acct_usdc=489_000.0,
+        )
+        mid_before = inv.effective_usdc / inv.effective_token
+        inv.on_bid_fill(px=249.25, sz=1.0)
+        mid_after = inv.effective_usdc / inv.effective_token
+        assert mid_after < mid_before  # bought tokens → less USDC, more token → lower mid
+
+    def test_ask_fill_virtual_balances(self) -> None:
+        inv = _make_inv(
+            alloc_token=5.0, alloc_usdc=1250.0,
+            acct_token=81.0, acct_usdc=489_000.0,
+        )
+        inv.on_ask_fill(px=250.75, sz=1.0)
+        assert inv.virtual_token == pytest.approx(4.0)
+        assert inv.virtual_usdc == pytest.approx(1500.75)
+        assert inv.effective_token == pytest.approx(4.0)
+        assert inv.effective_usdc == pytest.approx(1500.75)
+
+    def test_bid_fill_virtual_balances(self) -> None:
+        inv = _make_inv(
+            alloc_token=5.0, alloc_usdc=1250.0,
+            acct_token=81.0, acct_usdc=489_000.0,
+        )
+        inv.on_bid_fill(px=249.25, sz=1.0)
+        assert inv.virtual_token == pytest.approx(6.0)
+        assert inv.virtual_usdc == pytest.approx(1000.75)
+        assert inv.effective_token == pytest.approx(6.0)
+        assert inv.effective_usdc == pytest.approx(1000.75)
+
+
+# ===========================================================================
+# 3. Fee Accounting
+# ===========================================================================
+
+
+class TestFeeAccounting:
+    def test_ask_fill_usdc_fee(self) -> None:
+        inv = _make_inv(alloc_token=10.0, alloc_usdc=0.0, acct_token=10.0, acct_usdc=500.0)
+        inv.on_ask_fill(px=100.0, sz=1.0, fee=0.05, fee_token="USDC")
+        assert inv.virtual_token == pytest.approx(9.0)
+        assert inv.virtual_usdc == pytest.approx(99.95)  # 100 - 0.05
+
+    def test_bid_fill_usdc_fee(self) -> None:
+        inv = _make_inv(alloc_token=0.0, alloc_usdc=500.0, acct_token=100.0, acct_usdc=500.0)
+        inv.on_bid_fill(px=100.0, sz=1.0, fee=0.05, fee_token="USDC")
+        assert inv.virtual_token == pytest.approx(1.0)
+        assert inv.virtual_usdc == pytest.approx(399.95)  # 500 - 100 - 0.05
+
+    def test_ask_fill_token_fee(self) -> None:
+        inv = _make_inv(alloc_token=10.0, alloc_usdc=0.0, acct_token=10.0, acct_usdc=500.0)
+        inv.on_ask_fill(px=100.0, sz=1.0, fee=0.01, fee_token="THC")
+        assert inv.virtual_token == pytest.approx(8.99)  # 10 - 1.0 - 0.01
+        assert inv.virtual_usdc == pytest.approx(100.0)  # no USDC fee deducted
+
+    def test_bid_fill_token_fee(self) -> None:
+        inv = _make_inv(alloc_token=0.0, alloc_usdc=500.0, acct_token=100.0, acct_usdc=500.0)
+        inv.on_bid_fill(px=100.0, sz=1.0, fee=0.01, fee_token="THC")
+        assert inv.virtual_token == pytest.approx(0.99)  # 1.0 - 0.01
+        assert inv.virtual_usdc == pytest.approx(400.0)
+
+    def test_zero_fee_default(self) -> None:
+        """Fills without fee args should work (backwards compatible)."""
+        inv = _make_inv(alloc_token=10.0, alloc_usdc=0.0, acct_token=10.0, acct_usdc=500.0)
+        inv.on_ask_fill(px=100.0, sz=1.0)
+        assert inv.virtual_token == pytest.approx(9.0)
+        assert inv.virtual_usdc == pytest.approx(100.0)
+
+
+# ===========================================================================
+# 4. Balance Reconciliation Does NOT Reset Virtual
 # ===========================================================================
 
 
 class TestBalanceReconciliation:
-    def test_account_above_allocation(self) -> None:
-        inv = _make_inv(alloc_token=100.0, alloc_usdc=180.0)
-        inv.on_balance_update(token=150.0, usdc=200.0)
-        assert inv.account_token == 150.0
-        assert inv.effective_token == 100.0
-        assert inv.account_usdc == 200.0
-        assert inv.effective_usdc == 180.0
+    def test_balance_update_does_not_reset_virtual(self) -> None:
+        """Critical: reconciliation must not touch virtual balances."""
+        inv = _make_inv(
+            alloc_token=5.0, alloc_usdc=1250.0,
+            acct_token=81.0, acct_usdc=489_000.0,
+        )
+        # Simulate a fill
+        inv.on_ask_fill(px=250.0, sz=1.0)
+        assert inv.virtual_token == pytest.approx(4.0)
+        assert inv.virtual_usdc == pytest.approx(1500.0)
 
-    def test_account_below_allocation(self) -> None:
-        inv = _make_inv(alloc_token=100.0, alloc_usdc=200.0)
-        inv.on_balance_update(token=50.0, usdc=100.0)
-        assert inv.account_token == 50.0
-        assert inv.effective_token == 50.0
-        assert inv.account_usdc == 100.0
-        assert inv.effective_usdc == 100.0
+        # Reconciliation updates account balances
+        inv.on_balance_update(token=80.0, usdc=489_250.0)
+        # Virtual must be UNCHANGED
+        assert inv.virtual_token == pytest.approx(4.0)
+        assert inv.virtual_usdc == pytest.approx(1500.0)
+        # Effective = min(virtual, account) — virtual is lower
+        assert inv.effective_token == pytest.approx(4.0)
+        assert inv.effective_usdc == pytest.approx(1500.0)
 
-    def test_both_sides_mixed(self) -> None:
-        inv = _make_inv(alloc_token=80.0, alloc_usdc=150.0)
-        inv.on_balance_update(token=100.0, usdc=120.0)
-        # token above alloc, usdc below alloc
-        assert inv.effective_token == 80.0
-        assert inv.effective_usdc == 120.0
+    def test_balance_update_caps_effective_when_account_low(self) -> None:
+        inv = _make_inv(
+            alloc_token=5.0, alloc_usdc=1250.0,
+            acct_token=81.0, acct_usdc=489_000.0,
+        )
+        # Account drops below virtual (e.g., other strategy spent funds)
+        inv.on_balance_update(token=3.0, usdc=800.0)
+        assert inv.virtual_token == pytest.approx(5.0)  # unchanged
+        assert inv.virtual_usdc == pytest.approx(1250.0)  # unchanged
+        assert inv.effective_token == pytest.approx(3.0)  # capped by account
+        assert inv.effective_usdc == pytest.approx(800.0)
 
-    def test_zero_balances(self) -> None:
+    def test_zero_account_balances(self) -> None:
         inv = _make_inv(alloc_token=100.0, alloc_usdc=100.0)
         inv.on_balance_update(token=0.0, usdc=0.0)
         assert inv.effective_token == 0.0
         assert inv.effective_usdc == 0.0
+        # Virtual unchanged
+        assert inv.virtual_token == 100.0
+        assert inv.virtual_usdc == 100.0
 
 
 # ===========================================================================
-# 5. Edge Cases and Integration
+# 5. Allocation Management
+# ===========================================================================
+
+
+class TestAllocationUpdate:
+    def test_increase_allocation(self) -> None:
+        inv = _make_inv(alloc_token=100.0, alloc_usdc=100.0, acct_token=200.0, acct_usdc=200.0)
+        inv.update_allocation(token=150.0, usdc=150.0)
+        # Virtual should increase by the delta
+        assert inv.virtual_token == pytest.approx(150.0)
+        assert inv.virtual_usdc == pytest.approx(150.0)
+        assert inv.effective_token == pytest.approx(150.0)
+
+    def test_decrease_allocation(self) -> None:
+        inv = _make_inv(alloc_token=100.0, alloc_usdc=100.0, acct_token=200.0, acct_usdc=200.0)
+        inv.update_allocation(token=60.0, usdc=60.0)
+        assert inv.virtual_token == pytest.approx(60.0)
+        assert inv.virtual_usdc == pytest.approx(60.0)
+
+    def test_allocation_update_after_fills(self) -> None:
+        inv = _make_inv(alloc_token=100.0, alloc_usdc=0.0, acct_token=100.0, acct_usdc=500.0)
+        inv.on_ask_fill(px=10.0, sz=5.0)
+        # virtual: token=95, usdc=50
+        inv.update_allocation(token=120.0, usdc=20.0)
+        # delta: token +20, usdc +20
+        assert inv.virtual_token == pytest.approx(115.0)
+        assert inv.virtual_usdc == pytest.approx(70.0)
+
+
+# ===========================================================================
+# 6. Fill Sequence — Realistic Scenario
+# ===========================================================================
+
+
+class TestFillSequence:
+    def test_alternating_fills_change_mid(self) -> None:
+        """Simulate the HIP-2 grid: fills should move mid back and forth."""
+        inv = _make_inv(
+            alloc_token=5.0, alloc_usdc=1250.0,
+            acct_token=81.0, acct_usdc=489_000.0,
+        )
+        initial_mid = inv.effective_usdc / inv.effective_token  # 250.0
+
+        # Sell 1 token
+        inv.on_ask_fill(px=250.75, sz=1.0)
+        mid_after_sell = inv.effective_usdc / inv.effective_token
+        assert mid_after_sell > initial_mid
+
+        # Buy 1 token back
+        inv.on_bid_fill(px=249.25, sz=1.0)
+        mid_after_buy = inv.effective_usdc / inv.effective_token
+        assert mid_after_buy < mid_after_sell
+
+    def test_many_fills_with_fees(self) -> None:
+        inv = _make_inv(
+            alloc_token=10.0, alloc_usdc=2500.0,
+            acct_token=100.0, acct_usdc=100_000.0,
+        )
+        # Sell 3 tokens at different prices
+        inv.on_ask_fill(px=250.0, sz=1.0, fee=0.025, fee_token="USDC")
+        inv.on_ask_fill(px=250.75, sz=1.0, fee=0.025, fee_token="USDC")
+        inv.on_ask_fill(px=251.50, sz=1.0, fee=0.025, fee_token="USDC")
+
+        assert inv.virtual_token == pytest.approx(7.0)
+        expected_usdc = 2500.0 + (250.0 - 0.025) + (250.75 - 0.025) + (251.50 - 0.025)
+        assert inv.virtual_usdc == pytest.approx(expected_usdc)
+
+        # Account is untouched by fills
+        assert inv.account_token == 100.0
+        assert inv.account_usdc == 100_000.0
+
+
+# ===========================================================================
+# 7. Edge Cases & Invariants
 # ===========================================================================
 
 
 class TestEdgeCases:
-    def test_effective_never_exceeds_min_after_construction(self) -> None:
+    def test_effective_never_exceeds_min_virtual_account(self) -> None:
         for at, al in [(100, 50), (50, 100), (0, 100), (100, 0)]:
             inv = _make_inv(acct_token=float(at), alloc_token=float(al))
-            assert inv.effective_token <= min(inv.allocated_token, inv.account_token)
+            assert inv.effective_token <= min(inv.virtual_token, inv.account_token)
 
-    def test_effective_never_exceeds_min_after_fill(self) -> None:
+    def test_effective_invariant_after_fills(self) -> None:
         inv = _make_inv(
             acct_token=50.0, alloc_token=60.0,
             acct_usdc=100.0, alloc_usdc=100.0,
         )
         for _ in range(10):
             inv.on_bid_fill(px=1.0, sz=5.0)
-            assert inv.effective_token <= min(inv.allocated_token, inv.account_token)
-            assert inv.effective_usdc <= min(inv.allocated_usdc, inv.account_usdc)
+            assert inv.effective_token <= min(inv.virtual_token, inv.account_token)
+            assert inv.effective_usdc <= min(inv.virtual_usdc, inv.account_usdc)
 
-    def test_effective_never_exceeds_min_after_ask_fill(self) -> None:
+    def test_effective_invariant_after_ask_fills(self) -> None:
         inv = _make_inv(
             acct_token=100.0, alloc_token=100.0,
-            acct_usdc=0.0, alloc_usdc=50.0,
+            acct_usdc=0.0, alloc_usdc=500.0,
         )
         for _ in range(5):
             inv.on_ask_fill(px=1.0, sz=10.0)
-            assert inv.effective_token <= min(inv.allocated_token, inv.account_token)
-            assert inv.effective_usdc <= min(inv.allocated_usdc, inv.account_usdc)
+            assert inv.effective_token <= min(inv.virtual_token, inv.account_token)
+            assert inv.effective_usdc <= min(inv.virtual_usdc, inv.account_usdc)
 
-    def test_effective_never_exceeds_min_after_reconciliation(self) -> None:
+    def test_effective_invariant_after_reconciliation(self) -> None:
         inv = _make_inv(alloc_token=80.0, alloc_usdc=80.0)
         for t, u in [(200, 200), (50, 50), (0, 0), (80, 80), (1000, 10)]:
             inv.on_balance_update(token=float(t), usdc=float(u))
-            assert inv.effective_token <= min(inv.allocated_token, inv.account_token)
-            assert inv.effective_usdc <= min(inv.allocated_usdc, inv.account_usdc)
+            assert inv.effective_token <= min(inv.virtual_token, inv.account_token)
+            assert inv.effective_usdc <= min(inv.virtual_usdc, inv.account_usdc)
 
-    def test_effective_never_exceeds_min_after_allocation_update(self) -> None:
+    def test_effective_invariant_after_allocation_update(self) -> None:
         inv = _make_inv(acct_token=100.0, acct_usdc=100.0)
         for al_t, al_u in [(50, 50), (200, 200), (0, 0), (100, 100)]:
             inv.update_allocation(token=float(al_t), usdc=float(al_u))
-            assert inv.effective_token <= min(inv.allocated_token, inv.account_token)
-            assert inv.effective_usdc <= min(inv.allocated_usdc, inv.account_usdc)
+            assert inv.effective_token <= min(inv.virtual_token, inv.account_token)
+            assert inv.effective_usdc <= min(inv.virtual_usdc, inv.account_usdc)
+
+    def test_account_balances_not_changed_by_fills(self) -> None:
+        """Fills should only move virtual balances, not account balances."""
+        inv = _make_inv(acct_token=100.0, acct_usdc=5000.0)
+        inv.on_ask_fill(px=50.0, sz=2.0)
+        assert inv.account_token == 100.0
+        assert inv.account_usdc == 5000.0
+        inv.on_bid_fill(px=49.0, sz=3.0)
+        assert inv.account_token == 100.0
+        assert inv.account_usdc == 5000.0

--- a/tests/test_ws_state.py
+++ b/tests/test_ws_state.py
@@ -270,7 +270,11 @@ async def test_reconciliation_updates_balances():
 
 async def test_fill_callback_updates_order_state_and_inventory():
     """userFills callback routes to OrderState.on_fill → Inventory."""
-    ws, _, _ = _make_ws_state(info=_make_info(token_bal=100.0, usdc_bal=500.0))
+    ws, _, _ = _make_ws_state(
+        info=_make_info(token_bal=100.0, usdc_bal=500.0),
+        allocated_token=100.0,
+        allocated_usdc=500.0,
+    )
     await ws._startup()
 
     # Place an ask order in state
@@ -287,12 +291,16 @@ async def test_fill_callback_updates_order_state_and_inventory():
     assert 42 not in ws.order_state.orders_by_oid
     # Inventory should reflect the fill (sold tokens, gained USDC)
     assert ws.inventory is not None
-    assert ws.inventory.account_token < initial_token
+    assert ws.inventory.virtual_token < initial_token
 
 
 async def test_duplicate_fill_ignored():
     """Duplicate tid is ignored by OrderState dedup."""
-    ws, _, _ = _make_ws_state(info=_make_info(token_bal=100.0, usdc_bal=500.0))
+    ws, _, _ = _make_ws_state(
+        info=_make_info(token_bal=100.0, usdc_bal=500.0),
+        allocated_token=100.0,
+        allocated_usdc=500.0,
+    )
     await ws._startup()
 
     ws.order_state.on_place_confirmed(
@@ -303,11 +311,11 @@ async def test_duplicate_fill_ignored():
     # First fill — partial (SDK sends nested dict)
     fill = {"tid": 1001, "oid": 42, "sz": "10.0", "px": "1.015"}
     await ws._handle_fill({"user": "0xtest", "fills": [fill]})
-    token_after_first = ws.inventory.account_token
+    token_after_first = ws.inventory.virtual_token
 
     # Duplicate fill — should be ignored
     await ws._handle_fill({"user": "0xtest", "fills": [fill]})
-    assert ws.inventory.account_token == token_after_first
+    assert ws.inventory.virtual_token == token_after_first
 
 
 async def test_order_update_resting_adds_to_state():


### PR DESCRIPTION
## Summary

- **Rewrite quoting engine** to match HIP-2: mid price emerges from `effective_usdc / effective_token` ratio, grid generated per-tick using `generate_ask_levels` / `generate_bid_levels`, orders sized by walking available balance
- **Virtual isolated balances** (fixes #28): `virtual_token` / `virtual_usdc` start at allocation, adjusted only by fills (with fee accounting). Account balance is a hard safety cap, not an input to pricing. Reconciliation updates account balances without resetting virtual balances — enables multiple strategies on one wallet
- **Fee accounting**: fill handlers accept `fee` + `fee_token` from exchange fill data, correctly deducting fees from virtual balances

## Key changes

- `inventory.py`: 3-layer → 4-layer model (`allocated` → `virtual` → `account` → `effective`), fills adjust virtual only
- `quoting_engine.py`: pure function `compute_desired_orders(effective_token, effective_usdc, order_sz, n_orders)` with inventory-derived mid
- `pricing_grid.py`: added `generate_ask_levels` / `generate_bid_levels` for per-tick grid generation
- `ws_state.py`: passes `fee`/`feeToken` from fills to inventory, reconciliation no longer resets virtual balances
- `order_differ.py`: updated for new `DesiredOrder` shape
- Full test rewrites + new `test_fill_coverage.py` integration tests with `MockExchange`

## Test plan

- [x] All 234 tests pass
- [x] `ruff check` clean
- [x] `mypy` clean
- [ ] Manual test on testnet with shared wallet (multiple markets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)