### PR TITLE
Fix WS handlers to unwrap SDK channel wrapper

### DIFF
--- a/src/pyperliquidity/ws_state.py
+++ b/src/pyperliquidity/ws_state.py
@@ -254,10 +254,19 @@ class WsState:
     # -- Async handlers --------------------------------------------------------
 
     async def _handle_order_update(self, msg: Any) -> None:
-        """Route orderUpdates to OrderState."""
-        if not isinstance(msg, list):
-            msg = [msg]
-        for update in msg:
+        """Route orderUpdates to OrderState.
+
+        The SDK passes the full WS message: ``{"channel": "orderUpdates", "data": [...]}``.
+        We unwrap ``data`` before iterating.
+        """
+        if isinstance(msg, dict):
+            data = msg.get("data")
+            updates = data if isinstance(data, list) else [msg]
+        elif isinstance(msg, list):
+            updates = msg
+        else:
+            return
+        for update in updates:
             status = update.get("status", "")
             order = update.get("order", {})
             oid = order.get("oid")
@@ -281,9 +290,20 @@ class WsState:
                 self.order_state.remove_ghost(oid)
 
     async def _handle_fill(self, msg: Any) -> None:
-        """Route userFills to OrderState → Inventory."""
+        """Route userFills to OrderState → Inventory.
+
+        The SDK passes the full WS message:
+        ``{"channel": "userFills", "data": {"user": "...", "fills": [...]}}``.
+        We unwrap ``data`` then extract ``fills``.
+        """
         if isinstance(msg, dict):
-            fills = msg.get("fills", [])
+            data = msg.get("data", msg)
+            if isinstance(data, dict):
+                fills = data.get("fills", [])
+            elif isinstance(data, list):
+                fills = data
+            else:
+                fills = []
         elif isinstance(msg, list):
             fills = msg
         else:
@@ -312,12 +332,19 @@ class WsState:
                     )
 
     async def _handle_balance_update(self, msg: Any) -> None:
-        """Route webData2 balance updates to Inventory."""
+        """Route webData2 balance updates to Inventory.
+
+        The SDK passes the full WS message:
+        ``{"channel": "webData2", "data": {"user": "...", "spotBalances": [...]}}``.
+        We unwrap ``data`` before extracting balances.
+        """
         if self.inventory is None:
             return
-        balances = msg if isinstance(msg, dict) else {}
-        # webData2 typically has a "clearinghouseState" or similar structure.
-        # Extract spot balances from the message.
+        if not isinstance(msg, dict):
+            return
+        balances = msg.get("data", msg)
+        if not isinstance(balances, dict):
+            return
         spot_balances = balances.get("spotBalances", balances.get("balances", []))
         if not isinstance(spot_balances, list):
             return

--- a/tests/test_ws_state.py
+++ b/tests/test_ws_state.py
@@ -294,6 +294,35 @@ async def test_fill_callback_updates_order_state_and_inventory():
     assert ws.inventory.virtual_token < initial_token
 
 
+async def test_fill_sdk_wrapper_unwrapped():
+    """userFills from SDK wrapped in {"channel": ..., "data": {...}} are handled."""
+    ws, _, _ = _make_ws_state(
+        info=_make_info(token_bal=100.0, usdc_bal=500.0),
+        allocated_token=100.0,
+        allocated_usdc=500.0,
+    )
+    await ws._startup()
+
+    ws.order_state.on_place_confirmed(
+        oid=43, side="sell", level_index=5, price=1.015, size=10.0,
+    )
+    initial_token = ws.inventory.effective_token
+
+    # Full SDK wrapper format
+    fill_msg = {
+        "channel": "userFills",
+        "data": {
+            "user": "0xtest",
+            "fills": [{"tid": 1002, "oid": 43, "sz": "10.0", "px": "1.015"}],
+        },
+    }
+    await ws._handle_fill(fill_msg)
+
+    assert 43 not in ws.order_state.orders_by_oid
+    assert ws.inventory is not None
+    assert ws.inventory.virtual_token < initial_token
+
+
 async def test_duplicate_fill_ignored():
     """Duplicate tid is ignored by OrderState dedup."""
     ws, _, _ = _make_ws_state(
@@ -336,6 +365,29 @@ async def test_order_update_resting_adds_to_state():
 
     assert 77 in ws.order_state.orders_by_oid
     assert ws.order_state.orders_by_oid[77].side == "buy"
+
+
+async def test_order_update_sdk_wrapper_unwrapped():
+    """orderUpdates from SDK wrapped in {"channel": ..., "data": [...]} are handled."""
+    ws, _, _ = _make_ws_state()
+    await ws._startup()
+
+    msg = {
+        "channel": "orderUpdates",
+        "data": [{
+            "status": "open",
+            "order": {
+                "oid": 78,
+                "side": "A",
+                "limitPx": "1.009",
+                "sz": "5.0",
+            },
+        }],
+    }
+    await ws._handle_order_update(msg)
+
+    assert 78 in ws.order_state.orders_by_oid
+    assert ws.order_state.orders_by_oid[78].side == "sell"
 
 
 async def test_order_update_accepts_open_status():
@@ -393,6 +445,28 @@ async def test_balance_update_handler():
     assert ws.inventory is not None
     assert ws.inventory.account_token == 90.0
     assert ws.inventory.account_usdc == 550.0
+
+
+async def test_balance_update_sdk_wrapper_unwrapped():
+    """webData2 from SDK wrapped in {"channel": ..., "data": {...}} is handled."""
+    ws, _, _ = _make_ws_state(info=_make_info(token_bal=100.0, usdc_bal=500.0))
+    await ws._startup()
+
+    msg = {
+        "channel": "webData2",
+        "data": {
+            "user": "0xtest",
+            "spotBalances": [
+                {"coin": BASE_TOKEN_NAME, "total": "80.0"},
+                {"coin": "USDC", "total": "600.0"},
+            ],
+        },
+    }
+    await ws._handle_balance_update(msg)
+
+    assert ws.inventory is not None
+    assert ws.inventory.account_token == 80.0
+    assert ws.inventory.account_usdc == 600.0
 
 
 async def test_fill_flat_list_still_works():


### PR DESCRIPTION
## Summary

- All three WS handlers (`_handle_order_update`, `_handle_fill`, `_handle_balance_update`) failed to unwrap the SDK's `{"channel": "...", "data": ...}` wrapper, silently dropping all WebSocket events
- Orders were never registered via WS → fills returned `None` → virtual inventory never updated → mid price never shifted
- Adds 3 tests verifying the real SDK message format is handled correctly

Closes #23

## Test plan

- [x] All 237 tests pass (3 new SDK-wrapper tests added)
- [ ] Deploy to testnet and verify order updates, fills, and balance updates flow through WS handlers

🤖 Generated with [Claude Code](https://claude.com/claude-code)