### PR TITLE
Add active_levels windowing for large grids

### DIFF
--- a/src/pyperliquidity/cli.py
+++ b/src/pyperliquidity/cli.py
@@ -58,6 +58,10 @@ def _validate_config(config: dict[str, Any]) -> dict[str, Any]:
     if n_orders is None or n_orders <= 0:
         errors.append("strategy.n_orders must be a positive integer (total grid levels)")
 
+    active_levels = strategy.get("active_levels")
+    if active_levels is not None and (not isinstance(active_levels, int) or active_levels <= 0):
+        errors.append("strategy.active_levels must be a positive integer when provided")
+
     for key in ("allocated_token", "allocated_usdc"):
         val = allocation.get(key)
         if val is None or val <= 0:
@@ -118,6 +122,7 @@ def _build_ws_state(config: dict[str, Any], private_key: str, wallet: str) -> An
         min_notional=tuning["min_notional"],
         allocated_token=allocation["allocated_token"],
         allocated_usdc=allocation["allocated_usdc"],
+        active_levels=strategy.get("active_levels"),
     )
 
 

--- a/src/pyperliquidity/quoting_engine.py
+++ b/src/pyperliquidity/quoting_engine.py
@@ -29,6 +29,7 @@ def compute_desired_orders(
     effective_usdc: float,
     order_sz: float,
     min_notional: float = 0.0,
+    active_levels: int | None = None,
 ) -> list[DesiredOrder]:
     """Compute desired resting orders from a fixed grid and effective balances.
 
@@ -53,6 +54,9 @@ def compute_desired_orders(
         Size of a full order tranche.
     min_notional : float
         Minimum ``price * size`` for an order. Orders below this are excluded.
+    active_levels : int | None
+        Maximum number of levels to place per side of the cursor.
+        When ``None``, all available levels get orders (current behavior).
 
     Returns
     -------
@@ -74,32 +78,38 @@ def compute_desired_orders(
     orders: list[DesiredOrder] = []
 
     # --- Ask placement: ascending from cursor ---
+    ask_limit = active_levels if active_levels is not None else grid.n_orders
     if effective_token > 0:
         level = cursor
+        ask_count = 0
         # Partial ask at cursor level (if remainder > 0)
-        if partial_ask_sz > 0 and level < grid.n_orders:
+        if partial_ask_sz > 0 and level < grid.n_orders and ask_count < ask_limit:
             px = grid.price_at_level(level)
             if min_notional <= 0 or px * partial_ask_sz >= min_notional:
                 orders.append(DesiredOrder(
                     side="sell", level_index=level, price=px, size=partial_ask_sz,
                 ))
+            ask_count += 1
             level += 1
 
         # Full asks ascending
         asks_placed = 0
-        while asks_placed < n_full_asks and level < grid.n_orders:
+        while asks_placed < n_full_asks and level < grid.n_orders and ask_count < ask_limit:
             px = grid.price_at_level(level)
             if min_notional <= 0 or px * order_sz >= min_notional:
                 orders.append(DesiredOrder(
                     side="sell", level_index=level, price=px, size=order_sz,
                 ))
             asks_placed += 1
+            ask_count += 1
             level += 1
 
     # --- Bid placement: descending from cursor-1 ---
+    bid_limit = active_levels if active_levels is not None else grid.n_orders
     remaining_usdc = effective_usdc
+    bid_count = 0
     level = cursor - 1
-    while level >= 0 and remaining_usdc > 0:
+    while level >= 0 and remaining_usdc > 0 and bid_count < bid_limit:
         px = grid.price_at_level(level)
         cost = px * order_sz
         if remaining_usdc >= cost:
@@ -117,6 +127,7 @@ def compute_desired_orders(
                     side="buy", level_index=level, price=px, size=partial_sz,
                 ))
             remaining_usdc = 0
+        bid_count += 1
         level -= 1
 
     return orders

--- a/src/pyperliquidity/ws_state.py
+++ b/src/pyperliquidity/ws_state.py
@@ -58,6 +58,9 @@ class WsState:
         Maximum token balance the strategy may use (``inf`` = full account).
     allocated_usdc : float
         Maximum USDC balance the strategy may use (``inf`` = full account).
+    active_levels : int | None
+        Maximum number of levels to place per side of the cursor.
+        When ``None``, all available levels get orders.
     """
 
     def __init__(
@@ -77,6 +80,7 @@ class WsState:
         min_notional: float = 0.0,
         allocated_token: float = float("inf"),
         allocated_usdc: float = float("inf"),
+        active_levels: int | None = None,
     ) -> None:
         self.coin = coin
         self.start_px = start_px
@@ -90,6 +94,7 @@ class WsState:
         self.min_notional = min_notional
         self._allocated_token = allocated_token
         self._allocated_usdc = allocated_usdc
+        self.active_levels = active_levels
 
         self._info = info
         self._exchange = exchange
@@ -355,6 +360,7 @@ class WsState:
             effective_usdc=self.inventory.effective_usdc,
             order_sz=self.order_sz,
             min_notional=self.min_notional,
+            active_levels=self.active_levels,
         )
 
         current = self.order_state.get_current_orders()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -162,6 +162,29 @@ class TestValidateConfig:
         with pytest.raises(SystemExit, match="start_px"):
             _validate_config(cfg)
 
+    def test_active_levels_optional(self) -> None:
+        """active_levels is optional — omitting it should pass validation."""
+        result = _validate_config({**VALID_CONFIG})
+        assert result["strategy"].get("active_levels") is None
+
+    def test_active_levels_valid(self) -> None:
+        """Positive integer active_levels passes validation."""
+        cfg = {**VALID_CONFIG, "strategy": {**VALID_CONFIG["strategy"], "active_levels": 5}}
+        result = _validate_config(cfg)
+        assert result["strategy"]["active_levels"] == 5
+
+    def test_active_levels_zero_rejected(self) -> None:
+        """active_levels=0 is rejected."""
+        cfg = {**VALID_CONFIG, "strategy": {**VALID_CONFIG["strategy"], "active_levels": 0}}
+        with pytest.raises(SystemExit, match="active_levels"):
+            _validate_config(cfg)
+
+    def test_active_levels_negative_rejected(self) -> None:
+        """Negative active_levels is rejected."""
+        cfg = {**VALID_CONFIG, "strategy": {**VALID_CONFIG["strategy"], "active_levels": -1}}
+        with pytest.raises(SystemExit, match="active_levels"):
+            _validate_config(cfg)
+
     def test_multiple_errors_reported(self) -> None:
         """All validation errors should be reported at once."""
         cfg = {"market": {}, "strategy": {}, "allocation": {}}
@@ -194,3 +217,20 @@ class TestBuildWsStateAllocation:
 
         assert ws._allocated_token == 1000.0
         assert ws._allocated_usdc == 500.0
+        assert ws.active_levels is None
+
+    @patch("eth_account.Account")
+    @patch("hyperliquid.exchange.Exchange")
+    @patch("hyperliquid.info.Info")
+    def test_active_levels_passed_to_ws_state(
+        self, mock_info_cls: MagicMock, mock_exchange_cls: MagicMock, mock_account_cls: MagicMock,
+    ) -> None:
+        mock_info_cls.return_value = MagicMock()
+        mock_exchange_cls.return_value = MagicMock()
+        mock_account_cls.from_key.return_value = MagicMock()
+
+        cfg = {**VALID_CONFIG, "strategy": {**VALID_CONFIG["strategy"], "active_levels": 10}}
+        config = _validate_config(cfg)
+        ws = _build_ws_state(config, private_key="0xdeadbeef", wallet="0xabc")
+
+        assert ws.active_levels == 10

--- a/tests/test_quoting_engine.py
+++ b/tests/test_quoting_engine.py
@@ -344,6 +344,83 @@ class TestEdgeCases:
         assert r1 == r2
 
 
+# --- Active levels windowing ---
+
+
+class TestActiveLevels:
+    def test_active_levels_none_places_all(self) -> None:
+        """Default active_levels=None places orders on all available levels."""
+        grid = _grid(10)
+        orders = compute_desired_orders(grid, 5000.0, 50000.0, 1000.0, active_levels=None)
+        asks = [o for o in orders if o.side == "sell"]
+        bids = [o for o in orders if o.side == "buy"]
+        # cursor=5: 5 asks (5-9), 5 bids (4-0)
+        assert len(asks) == 5
+        assert len(bids) == 5
+
+    def test_active_levels_limits_asks(self) -> None:
+        """Only N asks placed near cursor when active_levels is set."""
+        grid = _grid(10)
+        # cursor=5, asks at 5,6,7,8,9 normally
+        orders = compute_desired_orders(grid, 5000.0, 50000.0, 1000.0, active_levels=2)
+        asks = sorted(
+            [o for o in orders if o.side == "sell"],
+            key=lambda o: o.level_index,
+        )
+        assert len(asks) == 2
+        # Nearest asks to cursor: levels 5 and 6
+        assert asks[0].level_index == 5
+        assert asks[1].level_index == 6
+
+    def test_active_levels_limits_bids(self) -> None:
+        """Only N bids placed near cursor when active_levels is set."""
+        grid = _grid(10)
+        # cursor=5, bids at 4,3,2,1,0 normally
+        orders = compute_desired_orders(grid, 5000.0, 50000.0, 1000.0, active_levels=2)
+        bids = sorted(
+            [o for o in orders if o.side == "buy"],
+            key=lambda o: -o.level_index,
+        )
+        assert len(bids) == 2
+        # Nearest bids to cursor: levels 4 and 3
+        assert bids[0].level_index == 4
+        assert bids[1].level_index == 3
+
+    def test_active_levels_both_sides(self) -> None:
+        """Combined windowing limits both sides independently."""
+        grid = _grid(20)
+        # cursor=10, 10 asks and 10 bids normally
+        orders = compute_desired_orders(grid, 10000.0, 50000.0, 1000.0, active_levels=3)
+        asks = [o for o in orders if o.side == "sell"]
+        bids = [o for o in orders if o.side == "buy"]
+        assert len(asks) == 3
+        assert len(bids) == 3
+
+    def test_active_levels_larger_than_available(self) -> None:
+        """active_levels > available levels = no truncation."""
+        grid = _grid(10)
+        # cursor=5, 5 asks and 5 bids available
+        orders_capped = compute_desired_orders(grid, 5000.0, 50000.0, 1000.0, active_levels=100)
+        orders_none = compute_desired_orders(grid, 5000.0, 50000.0, 1000.0, active_levels=None)
+        assert len(orders_capped) == len(orders_none)
+
+    def test_large_grid_with_window(self) -> None:
+        """Large grid (100 levels) with active_levels=5 → ~10 total orders."""
+        grid = _grid(100)
+        # 50000 tokens, order_sz=1000 → n_full=50, cursor=50
+        orders = compute_desired_orders(grid, 50000.0, 500000.0, 1000.0, active_levels=5)
+        asks = [o for o in orders if o.side == "sell"]
+        bids = [o for o in orders if o.side == "buy"]
+        assert len(asks) == 5
+        assert len(bids) == 5
+        # Verify asks are the 5 nearest to cursor (ascending)
+        ask_levels = sorted(a.level_index for a in asks)
+        assert ask_levels == [50, 51, 52, 53, 54]
+        # Verify bids are the 5 nearest to cursor (descending)
+        bid_levels = sorted((b.level_index for b in bids), reverse=True)
+        assert bid_levels == [49, 48, 47, 46, 45]
+
+
 # --- No forbidden imports ---
 
 


### PR DESCRIPTION
## Summary
- Adds `active_levels: int | None` parameter to `compute_desired_orders` that limits order placement to the nearest N levels per side of the cursor
- Threads the parameter through `WsState` and CLI config (`strategy.active_levels`)
- Large grids (e.g. 1,656 levels from $350–$50,000) now only place ~2*active_levels resting orders near the spread
- Backward compatible — defaults to `None` (all levels get orders, current behavior)

Closes #36

## Test plan
- [x] 6 new tests in `TestActiveLevels`: default behavior, ask limiting, bid limiting, both sides, larger-than-available, large grid windowing
- [x] 4 new CLI validation tests: optional, valid, zero rejected, negative rejected
- [x] 1 new `_build_ws_state` passthrough test
- [x] All 250 tests pass
- [x] `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)