### PR TITLE
Add target_px config option for cursor placement on wide grids

### DIFF
--- a/src/pyperliquidity/cli.py
+++ b/src/pyperliquidity/cli.py
@@ -38,7 +38,15 @@ def _load_env() -> tuple[str, str]:
 
 
 def _validate_config(config: dict[str, Any]) -> dict[str, Any]:
-    """Validate required fields and apply defaults for optional tuning params."""
+    """Validate required fields and apply defaults for optional tuning params.
+
+    When ``strategy.target_px`` is provided, ``allocation.allocated_token`` and
+    ``allocation.allocated_usdc`` are computed automatically and the
+    ``[allocation]`` section becomes optional.  When ``target_px`` is absent,
+    both allocation fields are required (backward compatible).
+    """
+    from pyperliquidity.pricing_grid import compute_allocation_from_target_px
+
     errors: list[str] = []
 
     # Required sections/fields
@@ -62,10 +70,51 @@ def _validate_config(config: dict[str, Any]) -> dict[str, Any]:
     if active_levels is not None and (not isinstance(active_levels, int) or active_levels <= 0):
         errors.append("strategy.active_levels must be a positive integer when provided")
 
-    for key in ("allocated_token", "allocated_usdc"):
-        val = allocation.get(key)
-        if val is None or val <= 0:
-            errors.append(f"allocation.{key} must be positive")
+    # --- target_px vs allocation validation ---
+    target_px = strategy.get("target_px")
+
+    if target_px is not None:
+        # target_px must be positive
+        if target_px <= 0:
+            errors.append("strategy.target_px must be positive")
+
+        # target_px must be >= start_px (validated after core strategy fields pass)
+        start_px = strategy.get("start_px")
+        if start_px is not None and start_px > 0 and target_px > 0:
+            if target_px < start_px:
+                errors.append(
+                    f"strategy.target_px ({target_px}) must be >= "
+                    f"strategy.start_px ({start_px})"
+                )
+
+        # Bail early if there are errors before trying to compute allocations
+        if errors:
+            sys.exit("Config validation failed:\n  " + "\n  ".join(errors))
+
+        # Compute allocations from target_px
+        order_sz = strategy["order_sz"]
+        start_px = strategy["start_px"]
+        try:
+            token, usdc = compute_allocation_from_target_px(
+                target_px=target_px,
+                start_px=start_px,
+                n_orders=n_orders,
+                order_sz=order_sz,
+            )
+        except ValueError as exc:
+            sys.exit(f"Config validation failed:\n  strategy.target_px: {exc}")
+
+        # Populate allocation section with computed values
+        config["allocation"] = {
+            "allocated_token": token,
+            "allocated_usdc": usdc,
+        }
+    else:
+        # No target_px — require explicit allocations (backward compatible)
+        for key in ("allocated_token", "allocated_usdc"):
+            val = allocation.get(key)
+            if val is None or val <= 0:
+                errors.append(f"allocation.{key} must be positive")
 
     if errors:
         sys.exit("Config validation failed:\n  " + "\n  ".join(errors))

--- a/src/pyperliquidity/pricing_grid.py
+++ b/src/pyperliquidity/pricing_grid.py
@@ -63,6 +63,11 @@ class PricingGrid:
             raise IndexError(f"Level index {i} out of range [0, {len(self._levels) - 1}]")
         return self._levels[i]
 
+    @property
+    def max_price(self) -> float:
+        """The highest price on the grid (last level)."""
+        return self._levels[-1]
+
     def level_for_price(self, px: float) -> int | None:
         """Nearest grid level index for *px*, or None if outside the grid range.
 
@@ -97,3 +102,71 @@ class PricingGrid:
         if px - left <= right - px:  # <= gives lower-index tie-breaking
             return idx - 1
         return idx
+
+
+def compute_allocation_from_target_px(
+    target_px: float,
+    start_px: float,
+    n_orders: int,
+    order_sz: float,
+    tick_size: float = 0.003,
+) -> tuple[float, float]:
+    """Compute (allocated_token, allocated_usdc) to place the cursor at *target_px*.
+
+    The cursor is the boundary between bids (below) and asks (at and above).
+    Given a target price, we find the nearest grid level and treat it as the
+    cursor: levels from cursor upward become ask levels funded by token,
+    levels below cursor become bid levels funded by USDC.
+
+    Parameters
+    ----------
+    target_px : float
+        Desired market price (where the cursor should sit).
+    start_px : float
+        Grid start price (px_0).
+    n_orders : int
+        Total number of grid levels.
+    order_sz : float
+        Size of a full order tranche.
+    tick_size : float
+        Multiplicative spacing between levels (default 0.3%).
+
+    Returns
+    -------
+    tuple[float, float]
+        ``(allocated_token, allocated_usdc)`` — the token and USDC amounts
+        needed so the cursor lands at the grid level nearest to *target_px*.
+
+    Raises
+    ------
+    ValueError
+        If *target_px* is below *start_px* or above the grid's maximum price.
+    """
+    grid = PricingGrid(start_px=start_px, n_orders=n_orders, tick_size=tick_size)
+
+    if target_px < start_px:
+        raise ValueError(
+            f"target_px ({target_px}) must be >= start_px ({start_px})"
+        )
+    if target_px > grid.max_price:
+        raise ValueError(
+            f"target_px ({target_px}) is above the grid maximum "
+            f"({grid.max_price}). Increase n_orders or lower target_px."
+        )
+
+    cursor_level = grid.level_for_price(target_px)
+    if cursor_level is None:
+        raise ValueError(
+            f"target_px ({target_px}) could not be mapped to a grid level"
+        )
+
+    # Ask levels: from cursor upward
+    ask_levels = n_orders - cursor_level
+    allocated_token = ask_levels * order_sz
+
+    # Bid levels: from cursor-1 downward, each costing order_sz * price_at_level
+    allocated_usdc = sum(
+        order_sz * grid.price_at_level(i) for i in range(cursor_level)
+    )
+
+    return (allocated_token, allocated_usdc)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -234,3 +234,173 @@ class TestBuildWsStateAllocation:
         ws = _build_ws_state(config, private_key="0xdeadbeef", wallet="0xabc")
 
         assert ws.active_levels == 10
+
+
+# ---------------------------------------------------------------------------
+# target_px config option
+# ---------------------------------------------------------------------------
+
+
+# Config with target_px instead of explicit allocations
+TARGET_PX_CONFIG = {
+    "market": {"coin": "PURR", "testnet": False},
+    "strategy": {"n_orders": 10, "order_sz": 100.0, "start_px": 1.0, "target_px": 1.009},
+}
+
+
+class TestTargetPxValidation:
+    def test_target_px_replaces_allocation_requirement(self) -> None:
+        """When target_px is set, allocation section is not required."""
+        result = _validate_config({**TARGET_PX_CONFIG})
+        assert result["allocation"]["allocated_token"] > 0
+        assert result["allocation"]["allocated_usdc"] > 0
+
+    def test_target_px_computes_correct_allocations(self) -> None:
+        """target_px auto-computes allocation that places cursor correctly."""
+        cfg = {
+            "market": {"coin": "PURR"},
+            "strategy": {
+                "n_orders": 20,
+                "order_sz": 50.0,
+                "start_px": 1.0,
+                "target_px": 1.0,  # cursor at level 0 = all asks
+            },
+        }
+        result = _validate_config(cfg)
+        # cursor=0 means all 20 levels are asks
+        assert result["allocation"]["allocated_token"] == 20 * 50.0
+        assert result["allocation"]["allocated_usdc"] == 0.0
+
+    def test_target_px_at_middle_of_grid(self) -> None:
+        """target_px in the middle of the grid splits allocations."""
+        from pyperliquidity.pricing_grid import PricingGrid
+
+        grid = PricingGrid(start_px=1.0, n_orders=20)
+        target = grid.levels[10]
+        cfg = {
+            "market": {"coin": "PURR"},
+            "strategy": {
+                "n_orders": 20,
+                "order_sz": 50.0,
+                "start_px": 1.0,
+                "target_px": target,
+            },
+        }
+        result = _validate_config(cfg)
+        assert result["allocation"]["allocated_token"] == 10 * 50.0
+        expected_usdc = sum(50.0 * grid.price_at_level(i) for i in range(10))
+        assert abs(result["allocation"]["allocated_usdc"] - expected_usdc) < 1e-10
+
+    def test_target_px_below_start_px_rejected(self) -> None:
+        """target_px < start_px is rejected."""
+        cfg = {
+            "market": {"coin": "PURR"},
+            "strategy": {
+                "n_orders": 10,
+                "order_sz": 100.0,
+                "start_px": 1.0,
+                "target_px": 0.5,
+            },
+        }
+        with pytest.raises(SystemExit, match="target_px.*must be >= .*start_px"):
+            _validate_config(cfg)
+
+    def test_target_px_above_grid_rejected(self) -> None:
+        """target_px above grid max is rejected."""
+        cfg = {
+            "market": {"coin": "PURR"},
+            "strategy": {
+                "n_orders": 10,
+                "order_sz": 100.0,
+                "start_px": 1.0,
+                "target_px": 999.0,
+            },
+        }
+        with pytest.raises(SystemExit, match="target_px"):
+            _validate_config(cfg)
+
+    def test_target_px_zero_rejected(self) -> None:
+        """target_px=0 is rejected."""
+        cfg = {
+            "market": {"coin": "PURR"},
+            "strategy": {
+                "n_orders": 10,
+                "order_sz": 100.0,
+                "start_px": 1.0,
+                "target_px": 0,
+            },
+        }
+        with pytest.raises(SystemExit, match="target_px must be positive"):
+            _validate_config(cfg)
+
+    def test_target_px_negative_rejected(self) -> None:
+        """Negative target_px is rejected."""
+        cfg = {
+            "market": {"coin": "PURR"},
+            "strategy": {
+                "n_orders": 10,
+                "order_sz": 100.0,
+                "start_px": 1.0,
+                "target_px": -1.0,
+            },
+        }
+        with pytest.raises(SystemExit, match="target_px must be positive"):
+            _validate_config(cfg)
+
+    def test_backward_compatible_without_target_px(self) -> None:
+        """Without target_px, allocation fields are still required."""
+        result = _validate_config({**VALID_CONFIG})
+        assert result["allocation"]["allocated_token"] == 1000.0
+        assert result["allocation"]["allocated_usdc"] == 500.0
+
+    def test_no_target_px_missing_allocation_rejected(self) -> None:
+        """Without target_px, missing allocations are still an error."""
+        cfg = {
+            "market": {"coin": "PURR"},
+            "strategy": {"n_orders": 10, "order_sz": 100.0, "start_px": 1.0},
+        }
+        with pytest.raises(SystemExit, match="allocated_token"):
+            _validate_config(cfg)
+
+    def test_target_px_optional(self) -> None:
+        """target_px is optional — omitting it should work with explicit allocations."""
+        result = _validate_config({**VALID_CONFIG})
+        # No target_px in the valid config
+        assert result["strategy"].get("target_px") is None
+        assert result["allocation"]["allocated_token"] == 1000.0
+
+
+class TestBuildWsStateWithTargetPx:
+    """Verify target_px computed allocations flow through to WsState."""
+
+    @patch("eth_account.Account")
+    @patch("hyperliquid.exchange.Exchange")
+    @patch("hyperliquid.info.Info")
+    def test_target_px_allocation_passed_to_ws_state(
+        self, mock_info_cls: MagicMock, mock_exchange_cls: MagicMock, mock_account_cls: MagicMock,
+    ) -> None:
+        mock_info_cls.return_value = MagicMock()
+        mock_exchange_cls.return_value = MagicMock()
+        mock_account_cls.from_key.return_value = MagicMock()
+
+        from pyperliquidity.pricing_grid import PricingGrid
+
+        grid = PricingGrid(start_px=1.0, n_orders=10)
+        target = grid.levels[5]
+        cfg = {
+            "market": {"coin": "PURR"},
+            "strategy": {
+                "n_orders": 10,
+                "order_sz": 100.0,
+                "start_px": 1.0,
+                "target_px": target,
+            },
+        }
+        config = _validate_config(cfg)
+        ws = _build_ws_state(config, private_key="0xdeadbeef", wallet="0xabc")
+
+        # cursor=5: 5 ask levels * 100 = 500 tokens
+        assert ws._allocated_token == 500.0
+        # 5 bid levels
+        expected_usdc = sum(100.0 * grid.price_at_level(i) for i in range(5))
+        assert abs(ws._allocated_usdc - expected_usdc) < 1e-10

--- a/tests/test_pricing_grid.py
+++ b/tests/test_pricing_grid.py
@@ -5,6 +5,7 @@ import pytest
 from pyperliquidity.pricing_grid import (
     PricingGrid,
     _default_round,
+    compute_allocation_from_target_px,
 )
 
 # --- 3.1 Standard grid generation ---
@@ -212,3 +213,114 @@ class TestDefaultRounding5sf:
         assert _default_round(1.23456789) == 1.2346
         assert _default_round(0.00123456789) == 0.0012346
         assert _default_round(12345.6789) == 12346.0
+
+
+# --- compute_allocation_from_target_px ---
+
+
+class TestComputeAllocationFromTargetPx:
+    def test_cursor_at_start_px(self) -> None:
+        """target_px == start_px → cursor=0, all levels are asks, no USDC needed."""
+        token, usdc = compute_allocation_from_target_px(
+            target_px=1.0, start_px=1.0, n_orders=10, order_sz=100.0,
+        )
+        assert token == 10 * 100.0  # all 10 levels are asks
+        assert usdc == 0.0  # no bid levels
+
+    def test_cursor_at_last_level(self) -> None:
+        """target_px at the last level → cursor=n_orders-1, 1 ask level, rest bids."""
+        grid = PricingGrid(start_px=1.0, n_orders=10)
+        last_px = grid.levels[-1]
+        token, usdc = compute_allocation_from_target_px(
+            target_px=last_px, start_px=1.0, n_orders=10, order_sz=100.0,
+        )
+        # cursor = 9, ask_levels = 10 - 9 = 1
+        assert token == 1 * 100.0
+        # bid_levels = 9 (levels 0..8)
+        expected_usdc = sum(100.0 * grid.price_at_level(i) for i in range(9))
+        assert abs(usdc - expected_usdc) < 1e-10
+
+    def test_cursor_at_middle(self) -> None:
+        """target_px near the middle places cursor at midpoint."""
+        grid = PricingGrid(start_px=1.0, n_orders=10)
+        mid_px = grid.levels[5]
+        token, usdc = compute_allocation_from_target_px(
+            target_px=mid_px, start_px=1.0, n_orders=10, order_sz=100.0,
+        )
+        # cursor = 5, ask_levels = 5, bid_levels = 5
+        assert token == 5 * 100.0
+        expected_usdc = sum(100.0 * grid.price_at_level(i) for i in range(5))
+        assert abs(usdc - expected_usdc) < 1e-10
+
+    def test_target_below_start_px_raises(self) -> None:
+        """target_px < start_px raises ValueError."""
+        with pytest.raises(ValueError, match="must be >= start_px"):
+            compute_allocation_from_target_px(
+                target_px=0.5, start_px=1.0, n_orders=10, order_sz=100.0,
+            )
+
+    def test_target_above_grid_raises(self) -> None:
+        """target_px above grid maximum raises ValueError."""
+        grid = PricingGrid(start_px=1.0, n_orders=10)
+        above_max = grid.levels[-1] * 1.1  # well above max
+        with pytest.raises(ValueError, match="above the grid maximum"):
+            compute_allocation_from_target_px(
+                target_px=above_max, start_px=1.0, n_orders=10, order_sz=100.0,
+            )
+
+    def test_token_plus_usdc_cover_full_grid(self) -> None:
+        """allocated_token * price + allocated_usdc should cover the entire grid's value."""
+        grid = PricingGrid(start_px=1.0, n_orders=20)
+        target_px = grid.levels[10]
+        token, usdc = compute_allocation_from_target_px(
+            target_px=target_px, start_px=1.0, n_orders=20, order_sz=50.0,
+        )
+        # The token allocation covers ask levels (10 levels * 50 = 500 tokens)
+        assert token == 10 * 50.0
+        # The USDC allocation covers bid levels (levels 0..9)
+        expected_usdc = sum(50.0 * grid.price_at_level(i) for i in range(10))
+        assert abs(usdc - expected_usdc) < 1e-10
+
+    def test_snaps_to_nearest_level(self) -> None:
+        """target_px between two levels snaps to the nearest one."""
+        grid = PricingGrid(start_px=1.0, n_orders=10)
+        # Price between level 3 and level 4, closer to level 3
+        between_px = grid.levels[3] * 0.8 + grid.levels[4] * 0.2
+        token, usdc = compute_allocation_from_target_px(
+            target_px=between_px, start_px=1.0, n_orders=10, order_sz=100.0,
+        )
+        # Should snap to level 3: cursor=3, ask_levels=7
+        assert token == 7 * 100.0
+
+    def test_roundtrip_with_quoting_engine(self) -> None:
+        """Computed allocations should produce the expected cursor in the quoting engine."""
+        from pyperliquidity.quoting_engine import compute_desired_orders
+
+        grid = PricingGrid(start_px=1.0, n_orders=20)
+        target_level = 8
+        target_px = grid.levels[target_level]
+        token, usdc = compute_allocation_from_target_px(
+            target_px=target_px, start_px=1.0, n_orders=20, order_sz=100.0,
+        )
+        orders = compute_desired_orders(
+            grid=grid, effective_token=token, effective_usdc=usdc, order_sz=100.0,
+        )
+        asks = [o for o in orders if o.side == "sell"]
+        bids = [o for o in orders if o.side == "buy"]
+        # Cursor should be at target_level
+        min_ask_level = min(a.level_index for a in asks)
+        max_bid_level = max(b.level_index for b in bids)
+        assert min_ask_level == target_level
+        assert max_bid_level == target_level - 1
+
+    def test_custom_tick_size(self) -> None:
+        """Works correctly with a non-default tick_size."""
+        grid = PricingGrid(start_px=1.0, n_orders=10, tick_size=0.01)
+        target_px = grid.levels[5]
+        token, usdc = compute_allocation_from_target_px(
+            target_px=target_px, start_px=1.0, n_orders=10,
+            order_sz=100.0, tick_size=0.01,
+        )
+        assert token == 5 * 100.0
+        expected_usdc = sum(100.0 * grid.price_at_level(i) for i in range(5))
+        assert abs(usdc - expected_usdc) < 1e-10


### PR DESCRIPTION
## Summary
Closes #39

- Adds `compute_allocation_from_target_px()` to `pricing_grid.py` — given a target price, auto-computes `allocated_token` and `allocated_usdc` to place the cursor at that grid level
- When `strategy.target_px` is set in config, `[allocation]` section becomes optional (computed automatically)
- Fully backward compatible — omitting `target_px` requires explicit allocations as before
- Validates `target_px` is positive, >= `start_px`, and within grid range

## Test plan
- [x] 9 new pricing_grid tests (computation, edge cases, roundtrip with quoting engine)
- [x] 11 new CLI tests (validation, backward compat, passthrough)
- [ ] CI passes on Python 3.11 and 3.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)