### PR TITLE
Fix cancel key and add szDecimals rounding in BatchEmitter

### DIFF
--- a/src/pyperliquidity/batch_emitter.py
+++ b/src/pyperliquidity/batch_emitter.py
@@ -95,6 +95,8 @@ class BatchEmitter:
         Order state tracker for lifecycle notifications.
     clock : callable
         Monotonic clock (default ``time.monotonic``).
+    sz_decimals : int
+        Number of decimal places to round order sizes to (default 5).
     """
 
     def __init__(
@@ -104,12 +106,14 @@ class BatchEmitter:
         exchange: Any,
         order_state: OrderState,
         clock: Any = time.monotonic,
+        sz_decimals: int = 5,
     ) -> None:
         self.coin = coin
         self.asset_id = asset_id
         self._exchange = exchange
         self._order_state = order_state
         self._clock = clock
+        self._sz_decimals = sz_decimals
         self._cooldowns: dict[tuple[str, str], float] = {}
         self._consecutive_rejects: dict[str, int] = {}
 
@@ -208,7 +212,7 @@ class BatchEmitter:
         cancel_oids: list[int],
         budget: RateLimitBudget,
     ) -> tuple[int, int]:
-        reqs = [{"coin": self.coin, "o": oid} for oid in cancel_oids]
+        reqs = [{"coin": self.coin, "oid": oid} for oid in cancel_oids]
 
         try:
             response = await asyncio.to_thread(self._exchange.bulk_cancel, reqs)
@@ -243,19 +247,29 @@ class BatchEmitter:
                 f"{tracked.side if tracked else None} desired_side={desired.side}"
             )
 
+        rounded: list[tuple[int, DesiredOrder, float]] = []
+        for oid, desired in modifies:
+            sz = round(desired.size, self._sz_decimals)
+            if sz <= 0:
+                continue
+            rounded.append((oid, desired, sz))
+
+        if not rounded:
+            return 0, 0
+
         reqs = [
             {
                 "oid": oid,
                 "order": {
                     "coin": self.coin,
                     "is_buy": desired.side == "buy",
-                    "sz": desired.size,
+                    "sz": sz,
                     "limit_px": desired.price,
                     "order_type": _ALO_ORDER_TYPE,
                     "reduce_only": False,
                 },
             }
-            for oid, desired in modifies
+            for oid, desired, sz in rounded
         ]
 
         try:
@@ -265,10 +279,10 @@ class BatchEmitter:
         finally:
             budget.on_request()
 
-        statuses = _parse_statuses(response, expected=len(modifies))
+        statuses = _parse_statuses(response, expected=len(rounded))
         n_ok = n_err = 0
 
-        for i, (original_oid, desired) in enumerate(modifies):
+        for i, (original_oid, desired, _sz) in enumerate(rounded):
             status = statuses[i] if i < len(statuses) else {}
 
             if "resting" in status:
@@ -311,16 +325,26 @@ class BatchEmitter:
         places: list[DesiredOrder],
         budget: RateLimitBudget,
     ) -> tuple[int, int]:
+        rounded: list[tuple[DesiredOrder, float]] = []
+        for d in places:
+            sz = round(d.size, self._sz_decimals)
+            if sz <= 0:
+                continue
+            rounded.append((d, sz))
+
+        if not rounded:
+            return 0, 0
+
         reqs = [
             {
                 "coin": self.coin,
                 "is_buy": d.side == "buy",
-                "sz": d.size,
+                "sz": sz,
                 "limit_px": d.price,
                 "order_type": _ALO_ORDER_TYPE,
                 "reduce_only": False,
             }
-            for d in places
+            for d, sz in rounded
         ]
 
         try:
@@ -328,10 +352,10 @@ class BatchEmitter:
         finally:
             budget.on_request()
 
-        statuses = _parse_statuses(response, expected=len(places))
+        statuses = _parse_statuses(response, expected=len(rounded))
         n_ok = n_err = 0
 
-        for i, desired in enumerate(places):
+        for i, (desired, _sz) in enumerate(rounded):
             status = statuses[i] if i < len(statuses) else {}
 
             if "resting" in status:

--- a/src/pyperliquidity/ws_state.py
+++ b/src/pyperliquidity/ws_state.py
@@ -141,7 +141,9 @@ class WsState:
         self.asset_id = spot_entry["index"] + 10_000
         # Resolve base token name (e.g. "@1434" → "THC") for balance lookups
         base_token_idx = spot_entry["tokens"][0]
-        self._balance_coin = spot_meta["tokens"][base_token_idx]["name"]
+        base_token = spot_meta["tokens"][base_token_idx]
+        self._balance_coin = base_token["name"]
+        self._sz_decimals: int = int(base_token.get("szDecimals", 5))
 
         # 2. Construct fixed PricingGrid
         self.grid = PricingGrid(start_px=self.start_px, n_orders=self.n_orders)
@@ -197,6 +199,7 @@ class WsState:
             asset_id=self.asset_id,
             exchange=self._exchange,
             order_state=self.order_state,
+            sz_decimals=self._sz_decimals,
         )
 
         logger.info(
@@ -516,7 +519,7 @@ class WsState:
         oids = [o.oid for o in resting]
         logger.info("Shutdown: cancelling %d resting order(s): %s", len(oids), oids)
 
-        cancel_reqs = [{"coin": self.coin, "o": oid} for oid in oids]
+        cancel_reqs = [{"coin": self.coin, "oid": oid} for oid in oids]
         try:
             response = await asyncio.to_thread(self._exchange.bulk_cancel, cancel_reqs)
             logger.info("Shutdown: bulk_cancel response: %s", response)

--- a/tests/test_batch_emitter.py
+++ b/tests/test_batch_emitter.py
@@ -504,6 +504,79 @@ async def test_truncated_cancel_response_propagates_error():
 
 # --- 5.14 Budget debited on SDK exception ------------------------------------
 
+async def test_cancel_uses_oid_key():
+    """Bug #32: cancel requests must use 'oid' key, not 'o'."""
+    emitter, ex, os, _ = _make_emitter()
+    os.on_place_confirmed(oid=42, side="buy", level_index=0, price=1.0, size=10.0)
+    ex.bulk_cancel.return_value = _ok([{}])
+
+    diff = OrderDiff(cancels=[42])
+    budget = _budget()
+    await emitter.emit(diff, budget)
+
+    cancel_reqs = ex.bulk_cancel.call_args[0][0]
+    assert cancel_reqs == [{"coin": "TEST", "oid": 42}]
+    assert "o" not in cancel_reqs[0]
+
+
+async def test_size_rounded_to_sz_decimals_on_place():
+    """Bug #33: sizes must be rounded to szDecimals before sending."""
+    emitter, ex, os, clock = _make_emitter()
+    emitter._sz_decimals = 2
+
+    ex.bulk_orders.return_value = _ok([{"resting": {"oid": 1}}])
+
+    diff = OrderDiff(places=[_desired(side="buy", level=0, px=1.0, sz=10.12345)])
+    budget = _budget()
+    await emitter.emit(diff, budget)
+
+    placed_reqs = ex.bulk_orders.call_args[0][0]
+    assert placed_reqs[0]["sz"] == 10.12
+
+
+async def test_size_rounded_to_sz_decimals_on_modify():
+    """Bug #33: sizes must be rounded to szDecimals before sending."""
+    emitter, ex, os, _ = _make_emitter()
+    emitter._sz_decimals = 3
+    os.on_place_confirmed(oid=100, side="buy", level_index=5, price=1.50, size=10.0)
+
+    ex.bulk_modify_orders_new.return_value = _ok([{"resting": {"oid": 100}}])
+
+    diff = OrderDiff(modifies=[(100, _desired(side="buy", level=5, px=1.55, sz=5.12349))])
+    budget = _budget()
+    await emitter.emit(diff, budget)
+
+    modify_reqs = ex.bulk_modify_orders_new.call_args[0][0]
+    assert modify_reqs[0]["order"]["sz"] == 5.123
+
+
+async def test_zero_size_after_rounding_skipped_on_place():
+    """Bug #33: orders that round to zero should be skipped."""
+    emitter, ex, os, _ = _make_emitter()
+    emitter._sz_decimals = 0
+
+    diff = OrderDiff(places=[_desired(side="buy", level=0, px=1.0, sz=0.4)])
+    budget = _budget()
+    result = await emitter.emit(diff, budget)
+
+    assert result.n_placed == 0
+    ex.bulk_orders.assert_not_called()
+
+
+async def test_zero_size_after_rounding_skipped_on_modify():
+    """Bug #33: modifies that round to zero should be skipped."""
+    emitter, ex, os, _ = _make_emitter()
+    emitter._sz_decimals = 0
+    os.on_place_confirmed(oid=100, side="buy", level_index=0, price=1.0, size=10.0)
+
+    diff = OrderDiff(modifies=[(100, _desired(side="buy", level=0, px=1.0, sz=0.4))])
+    budget = _budget()
+    result = await emitter.emit(diff, budget)
+
+    assert result.n_modified == 0
+    ex.bulk_modify_orders_new.assert_not_called()
+
+
 async def test_budget_debited_on_sdk_exception():
     emitter, ex, os, _ = _make_emitter()
 

--- a/tests/test_ws_state.py
+++ b/tests/test_ws_state.py
@@ -242,7 +242,7 @@ async def test_reconciliation_cancels_orphaned_order():
     # bulk_cancel should have been called with oid 999
     exchange.bulk_cancel.assert_called_once()
     cancel_reqs = exchange.bulk_cancel.call_args[0][0]
-    assert any(req["o"] == 999 for req in cancel_reqs)
+    assert any(req["oid"] == 999 for req in cancel_reqs)
 
 
 async def test_reconciliation_removes_ghost_order():
@@ -697,7 +697,7 @@ async def test_shutdown_cancels_all_resting_orders():
     # bulk_cancel should have been called with all 3 OIDs
     exchange.bulk_cancel.assert_called_once()
     cancel_reqs = exchange.bulk_cancel.call_args[0][0]
-    cancelled_oids = {req["o"] for req in cancel_reqs}
+    cancelled_oids = {req["oid"] for req in cancel_reqs}
     assert cancelled_oids == {100, 101, 102}
 
     # Order state should be cleared


### PR DESCRIPTION
## Summary

Fixes two bugs in `BatchEmitter` that block core order execution (closes #44):

- **Cancel key**: `_execute_cancels` used `"o"` instead of `"oid"`, causing all `bulk_cancel` calls to be rejected by the SDK. Also fixed in `ws_state.py` shutdown path.
- **Size rounding**: `_execute_modifies` and `_execute_places` passed raw float sizes without rounding to `szDecimals`, causing `ValueError` from `float_to_wire`. Added `sz_decimals` parameter to `BatchEmitter`, extracted from spot metadata at startup. Orders that round to zero are filtered out.

## Test plan

- [x] All 298 existing tests pass (2 tests updated to assert `"oid"` key)
- [x] 5 new tests added covering cancel key, size rounding on place/modify, and zero-size filtering

🤖 Generated with [Claude Code](https://claude.com/claude-code)