### PR TITLE
Add grid generator CLI tool

### DIFF
--- a/src/pyperliquidity/cli.py
+++ b/src/pyperliquidity/cli.py
@@ -185,24 +185,74 @@ def _build_ws_state(
     )
 
 
-def main() -> None:
-    """CLI entrypoint: pyperliquidity run --config config.toml."""
-    parser = argparse.ArgumentParser(prog="pyperliquidity")
-    sub = parser.add_subparsers(dest="command")
-    run_parser = sub.add_parser("run", help="Start the market maker")
-    run_parser.add_argument("--config", required=True, help="Path to config.toml")
-    run_parser.add_argument(
-        "--keep-orders",
-        action="store_true",
-        default=False,
-        help="Skip cancellation of resting orders on shutdown",
-    )
-    args = parser.parse_args()
+def _config_to_toml(config: dict[str, Any]) -> str:
+    """Serialize a config dict to TOML format.
 
-    if args.command != "run":
-        parser.print_help()
-        sys.exit(1)
+    Uses a simple f-string formatter — no external dependency needed since
+    the config structure is flat and known.
+    """
+    lines: list[str] = []
 
+    # [market]
+    m = config["market"]
+    lines.append("[market]")
+    lines.append(f'coin = "{m["coin"]}"')
+    lines.append(f"testnet = {'true' if m.get('testnet') else 'false'}")
+    lines.append("")
+
+    # [strategy]
+    s = config["strategy"]
+    lines.append("[strategy]")
+    lines.append(f"n_orders = {s['n_orders']}  # total grid levels")
+    lines.append(f"order_sz = {s['order_sz']}  # tokens per tranche")
+    lines.append(f"start_px = {s['start_px']}  # grid bottom price")
+    lines.append(f"target_px = {s['target_px']}  # initial cursor price")
+    if "active_levels" in s:
+        lines.append(f"active_levels = {s['active_levels']}  # max levels per side")
+    lines.append("")
+
+    # [allocation]
+    a = config["allocation"]
+    lines.append("[allocation]")
+    lines.append(f"allocated_token = {a['allocated_token']}")
+    lines.append(f"allocated_usdc = {a['allocated_usdc']}")
+    lines.append("")
+
+    # [tuning]
+    t = config.get("tuning", {})
+    if t:
+        lines.append("[tuning]")
+        for key, val in t.items():
+            lines.append(f"{key} = {val}")
+        lines.append("")
+
+    return "\n".join(lines) + "\n"
+
+
+def _print_grid_summary(config: dict[str, Any], warnings: list[Any]) -> None:
+    """Print a human-readable grid summary to stderr."""
+    s = config["strategy"]
+    a = config["allocation"]
+    m = config["market"]
+
+    print(f"Grid config for {m['coin']}:", file=sys.stderr)
+    print(f"  Price range: {s['start_px']} → (level {s['n_orders'] - 1})", file=sys.stderr)
+    print(f"  Grid levels: {s['n_orders']}", file=sys.stderr)
+    print(f"  Order size:  {s['order_sz']} tokens/tranche", file=sys.stderr)
+    print(f"  Target px:   {s['target_px']}", file=sys.stderr)
+    if "active_levels" in s:
+        print(f"  Active lvls: {s['active_levels']} per side", file=sys.stderr)
+    print(f"  Token alloc: {a['allocated_token']}", file=sys.stderr)
+    print(f"  USDC alloc:  {a['allocated_usdc']:.2f}", file=sys.stderr)
+    if m.get("testnet"):
+        print("  Network:     TESTNET", file=sys.stderr)
+
+    for w in warnings:
+        print(f"  WARNING [{w.code}]: {w.message}", file=sys.stderr)
+
+
+def _cmd_run(args: argparse.Namespace) -> None:
+    """Handle the 'run' subcommand."""
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(levelname)s %(message)s")
 
     config = _load_config(args.config)
@@ -216,3 +266,86 @@ def main() -> None:
     cancel_on_shutdown = not args.keep_orders
     ws_state = _build_ws_state(config, private_key, wallet, cancel_on_shutdown=cancel_on_shutdown)
     asyncio.run(ws_state.run())
+
+
+def _cmd_grid(args: argparse.Namespace) -> None:
+    """Handle the 'grid' subcommand — generate a config from market parameters."""
+    from pyperliquidity.grid_generator import generate_grid_config
+
+    min_px, max_px = args.price_range
+
+    try:
+        config, warnings = generate_grid_config(
+            coin=args.coin,
+            min_px=min_px,
+            max_px=max_px,
+            liquidity_token=args.liquidity_token,
+            target_px=args.target_px,
+            tick_size=args.tick_size,
+            active_levels=args.active_levels,
+            testnet=args.testnet,
+            sz_decimals=args.sz_decimals,
+            min_notional=args.min_notional,
+        )
+    except ValueError as exc:
+        sys.exit(f"Error: {exc}")
+
+    _print_grid_summary(config, warnings)
+
+    toml_str = _config_to_toml(config)
+    if args.output:
+        Path(args.output).write_text(toml_str)
+        print(f"Config written to {args.output}", file=sys.stderr)
+    else:
+        print(toml_str)
+
+
+def main() -> None:
+    """CLI entrypoint: pyperliquidity {run,grid}."""
+    parser = argparse.ArgumentParser(prog="pyperliquidity")
+    sub = parser.add_subparsers(dest="command")
+
+    # --- run subcommand ---
+    run_parser = sub.add_parser("run", help="Start the market maker")
+    run_parser.add_argument("--config", required=True, help="Path to config.toml")
+    run_parser.add_argument(
+        "--keep-orders",
+        action="store_true",
+        default=False,
+        help="Skip cancellation of resting orders on shutdown",
+    )
+
+    # --- grid subcommand ---
+    grid_parser = sub.add_parser("grid", help="Generate a config from market parameters")
+    grid_parser.add_argument("--coin", required=True, help="Market identifier (e.g. @1434)")
+    grid_parser.add_argument(
+        "--price-range", nargs=2, type=float, required=True, metavar=("MIN", "MAX"),
+        help="Price range for the grid (min max)",
+    )
+    grid_parser.add_argument(
+        "--liquidity-token", type=float, required=True,
+        help="Total token amount to allocate as ask liquidity",
+    )
+    grid_parser.add_argument("--target-px", type=float, default=None, help="Initial market price")
+    grid_parser.add_argument(
+        "--tick-size", type=float, default=0.003, help="Tick spacing (default 0.003)",
+    )
+    grid_parser.add_argument("--active-levels", type=int, default=None, help="Max levels per side")
+    grid_parser.add_argument("--testnet", action="store_true", default=False, help="Target testnet")
+    grid_parser.add_argument("--output", "-o", type=str, default=None, help="Write TOML to file")
+    grid_parser.add_argument(
+        "--sz-decimals", type=int, default=None, help="Round order_sz to N decimals",
+    )
+    grid_parser.add_argument(
+        "--min-notional", type=float, default=10.0, help="Min notional (default 10)",
+    )
+
+    args = parser.parse_args()
+
+    if args.command == "run":
+        _cmd_run(args)
+    elif args.command == "grid":
+        _cmd_grid(args)
+    else:
+        parser.print_help()
+        sys.exit(1)

--- a/src/pyperliquidity/grid_generator.py
+++ b/src/pyperliquidity/grid_generator.py
@@ -1,0 +1,233 @@
+"""Grid generator — pure functions to derive HIP-2 config from high-level market parameters.
+
+No I/O. Takes price range + token liquidity and produces a ready-to-use config dict.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any
+
+from pyperliquidity.pricing_grid import PricingGrid, compute_allocation_from_target_px
+
+
+@dataclass(frozen=True, slots=True)
+class GridWarning:
+    """Non-fatal warning emitted during grid config generation."""
+
+    code: str
+    message: str
+
+
+def compute_n_orders(min_px: float, max_px: float, tick_size: float = 0.003) -> int:
+    """Compute the number of grid levels to span [min_px, max_px].
+
+    Uses ``ceil(ln(max_px / min_px) / ln(1 + tick_size))``.
+
+    Raises
+    ------
+    ValueError
+        If min_px >= max_px or either is non-positive.
+    """
+    if min_px <= 0 or max_px <= 0:
+        raise ValueError(f"Prices must be positive (got min_px={min_px}, max_px={max_px})")
+    if min_px >= max_px:
+        raise ValueError(f"min_px ({min_px}) must be less than max_px ({max_px})")
+    return math.ceil(math.log(max_px / min_px) / math.log(1 + tick_size))
+
+
+def compute_order_sz(
+    liquidity_token: float,
+    n_orders: int,
+    target_px: float,
+    start_px: float,
+    tick_size: float = 0.003,
+) -> float:
+    """Derive tranche size from token liquidity and ask-level count.
+
+    The cursor sits at the grid level nearest to ``target_px``.  Ask levels
+    are everything from the cursor upward, so::
+
+        ask_levels = n_orders - cursor_level
+        order_sz   = liquidity_token / ask_levels
+
+    Raises
+    ------
+    ValueError
+        If inputs are invalid or target_px resolves to no ask levels.
+    """
+    if liquidity_token <= 0:
+        raise ValueError(f"liquidity_token must be positive (got {liquidity_token})")
+    if n_orders <= 0:
+        raise ValueError(f"n_orders must be positive (got {n_orders})")
+
+    grid = PricingGrid(start_px=start_px, n_orders=n_orders, tick_size=tick_size)
+    cursor_level = grid.level_for_price(target_px)
+    if cursor_level is None:
+        raise ValueError(
+            f"target_px ({target_px}) is outside the grid range "
+            f"[{grid.levels[0]}, {grid.levels[-1]}]"
+        )
+    ask_levels = n_orders - cursor_level
+    if ask_levels <= 0:
+        raise ValueError(
+            f"target_px ({target_px}) is at the top of the grid — no ask levels available"
+        )
+    return liquidity_token / ask_levels
+
+
+def generate_grid_config(
+    *,
+    coin: str,
+    min_px: float,
+    max_px: float,
+    liquidity_token: float,
+    target_px: float | None = None,
+    tick_size: float = 0.003,
+    active_levels: int | None = None,
+    testnet: bool = False,
+    sz_decimals: int | None = None,
+    min_notional: float = 10.0,
+) -> tuple[dict[str, Any], list[GridWarning]]:
+    """Generate a complete HIP-2 config dict from high-level market parameters.
+
+    Parameters
+    ----------
+    coin : str
+        Market identifier (e.g. ``"@1434"``).
+    min_px, max_px : float
+        Price range for the grid.
+    liquidity_token : float
+        Total token amount to allocate as ask liquidity.
+    target_px : float | None
+        Desired initial market price.  Defaults to geometric midpoint
+        ``sqrt(min_px * max_px)``, snapped to the nearest grid level.
+    tick_size : float
+        Multiplicative spacing between levels (default 0.3%).
+    active_levels : int | None
+        Maximum levels per side to keep active.
+    testnet : bool
+        Whether this config targets testnet.
+    sz_decimals : int | None
+        If provided, round order_sz to this many decimal places.
+    min_notional : float
+        Minimum notional value (price * size) for an order.
+
+    Returns
+    -------
+    tuple[dict, list[GridWarning]]
+        Config dict suitable for TOML serialization + list of warnings.
+    """
+    if min_px <= 0 or max_px <= 0:
+        raise ValueError(f"Prices must be positive (got min_px={min_px}, max_px={max_px})")
+    if min_px >= max_px:
+        raise ValueError(f"min_px ({min_px}) must be less than max_px ({max_px})")
+    if liquidity_token <= 0:
+        raise ValueError(f"liquidity_token must be positive (got {liquidity_token})")
+
+    warnings: list[GridWarning] = []
+
+    # 1. Compute grid dimensions
+    n_orders = compute_n_orders(min_px, max_px, tick_size)
+    start_px = min_px
+
+    # 2. Build grid to validate non-degenerate
+    grid = PricingGrid(start_px=start_px, n_orders=n_orders, tick_size=tick_size)
+
+    # 3. Default target_px to geometric midpoint, snap to nearest grid level
+    if target_px is None:
+        target_px = math.sqrt(min_px * max_px)
+    cursor_level = grid.level_for_price(target_px)
+    if cursor_level is None:
+        raise ValueError(
+            f"target_px ({target_px}) is outside the grid range "
+            f"[{grid.levels[0]}, {grid.levels[-1]}]"
+        )
+    snapped_target_px = grid.price_at_level(cursor_level)
+
+    # 4. Compute order_sz from ask-level count
+    ask_levels = n_orders - cursor_level
+    if ask_levels <= 0:
+        raise ValueError(
+            f"target_px ({target_px}) is at the top of the grid — no ask levels available"
+        )
+    order_sz = liquidity_token / ask_levels
+    if sz_decimals is not None:
+        order_sz = round(order_sz, sz_decimals)
+
+    # 5. Compute allocations
+    allocated_token, allocated_usdc = compute_allocation_from_target_px(
+        target_px=snapped_target_px,
+        start_px=start_px,
+        n_orders=n_orders,
+        order_sz=order_sz,
+        tick_size=tick_size,
+    )
+
+    # 6. Collect warnings
+    lowest_ask_notional = grid.price_at_level(cursor_level) * order_sz
+    if lowest_ask_notional < min_notional:
+        warnings.append(GridWarning(
+            code="below_min_notional",
+            message=(
+                f"Lowest ask notional ${lowest_ask_notional:.2f} is below "
+                f"min_notional ${min_notional:.2f}. Orders near the cursor "
+                f"may be filtered out at runtime."
+            ),
+        ))
+
+    if cursor_level > 0:
+        lowest_bid_notional = grid.price_at_level(cursor_level - 1) * order_sz
+        if lowest_bid_notional < min_notional:
+            warnings.append(GridWarning(
+                code="below_min_notional_bid",
+                message=(
+                    f"Lowest bid notional ${lowest_bid_notional:.2f} is below "
+                    f"min_notional ${min_notional:.2f}. Orders near the cursor "
+                    f"may be filtered out at runtime."
+                ),
+            ))
+
+    if active_levels is not None and active_levels > n_orders:
+        warnings.append(GridWarning(
+            code="active_levels_exceeds_grid",
+            message=(
+                f"active_levels ({active_levels}) exceeds n_orders ({n_orders}). "
+                f"All levels will be active."
+            ),
+        ))
+
+    if n_orders > 100 and active_levels is None:
+        warnings.append(GridWarning(
+            code="large_grid_no_active_levels",
+            message=(
+                f"Grid has {n_orders} levels but no active_levels limit. "
+                f"Consider setting --active-levels to reduce open orders."
+            ),
+        ))
+
+    # 7. Build config dict
+    config: dict[str, Any] = {
+        "market": {
+            "coin": coin,
+            "testnet": testnet,
+        },
+        "strategy": {
+            "n_orders": n_orders,
+            "order_sz": order_sz,
+            "start_px": start_px,
+            "target_px": snapped_target_px,
+        },
+        "allocation": {
+            "allocated_token": allocated_token,
+            "allocated_usdc": allocated_usdc,
+        },
+        "tuning": {
+            "min_notional": min_notional,
+        },
+    }
+    if active_levels is not None:
+        config["strategy"]["active_levels"] = active_levels
+
+    return config, warnings

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,13 +2,21 @@
 
 from __future__ import annotations
 
+import argparse
 import textwrap
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from pyperliquidity.cli import _build_ws_state, _load_config, _load_env, _validate_config
+from pyperliquidity.cli import (
+    _build_ws_state,
+    _cmd_grid,
+    _config_to_toml,
+    _load_config,
+    _load_env,
+    _validate_config,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -473,3 +481,129 @@ class TestBuildWsStateWithTargetPx:
         # 5 bid levels
         expected_usdc = sum(100.0 * grid.price_at_level(i) for i in range(5))
         assert abs(ws._allocated_usdc - expected_usdc) < 1e-10
+
+
+# ---------------------------------------------------------------------------
+# grid subcommand
+# ---------------------------------------------------------------------------
+
+
+class TestConfigToToml:
+    def test_basic_output(self) -> None:
+        config = {
+            "market": {"coin": "@1434", "testnet": True},
+            "strategy": {
+                "n_orders": 100,
+                "order_sz": 0.5,
+                "start_px": 350,
+                "target_px": 4000.0,
+                "active_levels": 20,
+            },
+            "allocation": {"allocated_token": 40.0, "allocated_usdc": 1000.0},
+            "tuning": {"min_notional": 10.0},
+        }
+        toml_str = _config_to_toml(config)
+        assert '[market]' in toml_str
+        assert 'coin = "@1434"' in toml_str
+        assert "testnet = true" in toml_str
+        assert "[strategy]" in toml_str
+        assert "n_orders = 100" in toml_str
+        assert "active_levels = 20" in toml_str
+        assert "[allocation]" in toml_str
+        assert "[tuning]" in toml_str
+
+    def test_no_active_levels(self) -> None:
+        config = {
+            "market": {"coin": "TEST", "testnet": False},
+            "strategy": {"n_orders": 10, "order_sz": 1.0, "start_px": 100, "target_px": 150.0},
+            "allocation": {"allocated_token": 10.0, "allocated_usdc": 500.0},
+            "tuning": {},
+        }
+        toml_str = _config_to_toml(config)
+        assert "active_levels" not in toml_str
+
+
+class TestGridSubcommand:
+    def test_basic_stdout(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Grid command outputs TOML to stdout."""
+        args = argparse.Namespace(
+            coin="@1434",
+            price_range=[350, 50000],
+            liquidity_token=40,
+            target_px=None,
+            tick_size=0.003,
+            active_levels=20,
+            testnet=True,
+            output=None,
+            sz_decimals=None,
+            min_notional=10.0,
+        )
+        _cmd_grid(args)
+        captured = capsys.readouterr()
+        assert "[market]" in captured.out
+        assert "@1434" in captured.out
+        assert "testnet = true" in captured.out
+        # Summary on stderr
+        assert "Grid config" in captured.err
+
+    def test_output_to_file(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        """--output writes TOML to a file instead of stdout."""
+        out_file = tmp_path / "out.toml"
+        args = argparse.Namespace(
+            coin="TEST",
+            price_range=[100, 200],
+            liquidity_token=50,
+            target_px=None,
+            tick_size=0.003,
+            active_levels=None,
+            testnet=False,
+            output=str(out_file),
+            sz_decimals=None,
+            min_notional=10.0,
+        )
+        _cmd_grid(args)
+        captured = capsys.readouterr()
+        assert out_file.exists()
+        content = out_file.read_text()
+        assert "[market]" in content
+        # stdout should be empty (TOML goes to file)
+        assert "[market]" not in captured.out
+        # stderr should note the file was written
+        assert "Config written to" in captured.err
+
+    def test_invalid_range_exits(self) -> None:
+        """min >= max should exit with error."""
+        args = argparse.Namespace(
+            coin="TEST",
+            price_range=[200, 100],
+            liquidity_token=50,
+            target_px=None,
+            tick_size=0.003,
+            active_levels=None,
+            testnet=False,
+            output=None,
+            sz_decimals=None,
+            min_notional=10.0,
+        )
+        with pytest.raises(SystemExit, match="must be less than"):
+            _cmd_grid(args)
+
+    def test_summary_on_stderr(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Summary info appears on stderr."""
+        args = argparse.Namespace(
+            coin="TEST",
+            price_range=[100, 200],
+            liquidity_token=50,
+            target_px=None,
+            tick_size=0.003,
+            active_levels=10,
+            testnet=False,
+            output=None,
+            sz_decimals=None,
+            min_notional=10.0,
+        )
+        _cmd_grid(args)
+        captured = capsys.readouterr()
+        assert "Grid levels:" in captured.err
+        assert "Order size:" in captured.err
+        assert "Active lvls: 10" in captured.err

--- a/tests/test_grid_generator.py
+++ b/tests/test_grid_generator.py
@@ -1,0 +1,275 @@
+"""Tests for pyperliquidity.grid_generator — pure grid config generation."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from pyperliquidity.cli import _validate_config
+from pyperliquidity.grid_generator import compute_n_orders, compute_order_sz, generate_grid_config
+from pyperliquidity.pricing_grid import PricingGrid
+from pyperliquidity.quoting_engine import compute_desired_orders
+
+# ---------------------------------------------------------------------------
+# compute_n_orders
+# ---------------------------------------------------------------------------
+
+
+class TestComputeNOrders:
+    def test_known_range(self) -> None:
+        """350 → 50000 at 0.3% tick should give a known n_orders."""
+        n = compute_n_orders(350, 50000)
+        # ln(50000/350) / ln(1.003) ≈ 1619.8 → ceil = 1620
+        assert n == math.ceil(math.log(50000 / 350) / math.log(1.003))
+
+    def test_small_range(self) -> None:
+        n = compute_n_orders(100, 110)
+        expected = math.ceil(math.log(110 / 100) / math.log(1.003))
+        assert n == expected
+
+    def test_single_tick(self) -> None:
+        """A range of exactly one tick should give 1."""
+        n = compute_n_orders(100, 100.3)
+        assert n >= 1
+
+    def test_min_equals_max_raises(self) -> None:
+        with pytest.raises(ValueError, match="must be less than"):
+            compute_n_orders(100, 100)
+
+    def test_min_greater_than_max_raises(self) -> None:
+        with pytest.raises(ValueError, match="must be less than"):
+            compute_n_orders(200, 100)
+
+    def test_negative_price_raises(self) -> None:
+        with pytest.raises(ValueError, match="must be positive"):
+            compute_n_orders(-1, 100)
+
+    def test_zero_price_raises(self) -> None:
+        with pytest.raises(ValueError, match="must be positive"):
+            compute_n_orders(0, 100)
+
+    def test_custom_tick_size(self) -> None:
+        n = compute_n_orders(100, 200, tick_size=0.01)
+        expected = math.ceil(math.log(2) / math.log(1.01))
+        assert n == expected
+
+
+# ---------------------------------------------------------------------------
+# compute_order_sz
+# ---------------------------------------------------------------------------
+
+
+class TestComputeOrderSz:
+    def test_basic(self) -> None:
+        """40 tokens over a grid where target is at the bottom → all ask levels."""
+        n = compute_n_orders(350, 50000)
+        # target at start_px → cursor=0 → ask_levels=n_orders
+        sz = compute_order_sz(40, n, target_px=350, start_px=350)
+        assert abs(sz - 40 / n) < 1e-10
+
+    def test_target_at_midpoint(self) -> None:
+        grid = PricingGrid(start_px=100, n_orders=20)
+        mid_level = grid.levels[10]
+        sz = compute_order_sz(50, 20, target_px=mid_level, start_px=100)
+        # cursor=10, ask_levels=10
+        assert abs(sz - 5.0) < 1e-10
+
+    def test_zero_liquidity_raises(self) -> None:
+        with pytest.raises(ValueError, match="liquidity_token must be positive"):
+            compute_order_sz(0, 10, target_px=100, start_px=100)
+
+    def test_negative_liquidity_raises(self) -> None:
+        with pytest.raises(ValueError, match="liquidity_token must be positive"):
+            compute_order_sz(-1, 10, target_px=100, start_px=100)
+
+    def test_zero_n_orders_raises(self) -> None:
+        with pytest.raises(ValueError, match="n_orders must be positive"):
+            compute_order_sz(10, 0, target_px=100, start_px=100)
+
+
+# ---------------------------------------------------------------------------
+# generate_grid_config
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateGridConfig:
+    def test_basic_config(self) -> None:
+        """Generate a basic config and verify structure."""
+        config, warnings = generate_grid_config(
+            coin="@1434",
+            min_px=350,
+            max_px=50000,
+            liquidity_token=40,
+            testnet=True,
+        )
+        assert config["market"]["coin"] == "@1434"
+        assert config["market"]["testnet"] is True
+        assert config["strategy"]["n_orders"] > 0
+        assert config["strategy"]["order_sz"] > 0
+        assert config["strategy"]["start_px"] == 350
+        assert config["strategy"]["target_px"] > 0
+        assert config["allocation"]["allocated_token"] > 0
+        assert config["allocation"]["allocated_usdc"] >= 0
+
+    def test_target_px_defaults_to_geometric_midpoint(self) -> None:
+        config, _ = generate_grid_config(
+            coin="TEST",
+            min_px=100,
+            max_px=400,
+            liquidity_token=100,
+        )
+        geo_mid = math.sqrt(100 * 400)  # = 200
+        grid = PricingGrid(
+            start_px=100,
+            n_orders=config["strategy"]["n_orders"],
+        )
+        snapped = grid.price_at_level(grid.level_for_price(geo_mid))
+        assert config["strategy"]["target_px"] == snapped
+
+    def test_explicit_target_px(self) -> None:
+        grid = PricingGrid(start_px=100, n_orders=compute_n_orders(100, 200))
+        target = grid.levels[10]
+        config, _ = generate_grid_config(
+            coin="TEST",
+            min_px=100,
+            max_px=200,
+            liquidity_token=50,
+            target_px=target,
+        )
+        assert config["strategy"]["target_px"] == target
+
+    def test_active_levels_in_config(self) -> None:
+        config, _ = generate_grid_config(
+            coin="TEST",
+            min_px=100,
+            max_px=200,
+            liquidity_token=50,
+            active_levels=10,
+        )
+        assert config["strategy"]["active_levels"] == 10
+
+    def test_active_levels_absent_when_not_set(self) -> None:
+        config, _ = generate_grid_config(
+            coin="TEST",
+            min_px=100,
+            max_px=200,
+            liquidity_token=50,
+        )
+        assert "active_levels" not in config["strategy"]
+
+    def test_sz_decimals_rounding(self) -> None:
+        config, _ = generate_grid_config(
+            coin="TEST",
+            min_px=100,
+            max_px=200,
+            liquidity_token=50,
+            sz_decimals=2,
+        )
+        sz = config["strategy"]["order_sz"]
+        assert sz == round(sz, 2)
+
+    def test_min_equals_max_raises(self) -> None:
+        with pytest.raises(ValueError, match="must be less than"):
+            generate_grid_config(
+                coin="TEST", min_px=100, max_px=100, liquidity_token=50,
+            )
+
+    def test_negative_liquidity_raises(self) -> None:
+        with pytest.raises(ValueError, match="liquidity_token must be positive"):
+            generate_grid_config(
+                coin="TEST", min_px=100, max_px=200, liquidity_token=-1,
+            )
+
+    def test_warning_below_min_notional(self) -> None:
+        """Tiny order sizes should trigger below_min_notional warning."""
+        config, warnings = generate_grid_config(
+            coin="TEST",
+            min_px=0.001,
+            max_px=0.01,
+            liquidity_token=1,
+            min_notional=10.0,
+        )
+        codes = [w.code for w in warnings]
+        assert "below_min_notional" in codes
+
+    def test_warning_active_levels_exceeds_grid(self) -> None:
+        config, warnings = generate_grid_config(
+            coin="TEST",
+            min_px=100,
+            max_px=110,
+            liquidity_token=50,
+            active_levels=9999,
+        )
+        codes = [w.code for w in warnings]
+        assert "active_levels_exceeds_grid" in codes
+
+    def test_warning_large_grid_no_active_levels(self) -> None:
+        config, warnings = generate_grid_config(
+            coin="TEST",
+            min_px=1,
+            max_px=10000,
+            liquidity_token=100,
+        )
+        assert config["strategy"]["n_orders"] > 100
+        codes = [w.code for w in warnings]
+        assert "large_grid_no_active_levels" in codes
+
+    def test_roundtrip_validate_config(self) -> None:
+        """Generated config should pass _validate_config."""
+        config, _ = generate_grid_config(
+            coin="@1434",
+            min_px=350,
+            max_px=50000,
+            liquidity_token=40,
+            active_levels=20,
+            testnet=True,
+        )
+        validated = _validate_config(config)
+        assert validated["market"]["coin"] == "@1434"
+        assert validated["allocation"]["allocated_token"] > 0
+
+    def test_roundtrip_produces_orders(self) -> None:
+        """Generated config should produce orders via compute_desired_orders."""
+        config, _ = generate_grid_config(
+            coin="TEST",
+            min_px=100,
+            max_px=200,
+            liquidity_token=50,
+            active_levels=10,
+        )
+        s = config["strategy"]
+        a = config["allocation"]
+        grid = PricingGrid(start_px=s["start_px"], n_orders=s["n_orders"])
+        orders = compute_desired_orders(
+            grid=grid,
+            effective_token=a["allocated_token"],
+            effective_usdc=a["allocated_usdc"],
+            order_sz=s["order_sz"],
+            active_levels=s.get("active_levels"),
+        )
+        assert len(orders) > 0
+        # Should have both buys and sells
+        sides = {o.side for o in orders}
+        assert "buy" in sides
+        assert "sell" in sides
+
+    def test_testnet_flag(self) -> None:
+        config, _ = generate_grid_config(
+            coin="TEST",
+            min_px=100,
+            max_px=200,
+            liquidity_token=50,
+            testnet=True,
+        )
+        assert config["market"]["testnet"] is True
+
+    def test_min_notional_in_tuning(self) -> None:
+        config, _ = generate_grid_config(
+            coin="TEST",
+            min_px=100,
+            max_px=200,
+            liquidity_token=50,
+            min_notional=15.0,
+        )
+        assert config["tuning"]["min_notional"] == 15.0


### PR DESCRIPTION
## Summary

- Adds `pyperliquidity grid` subcommand that generates a ready-to-use TOML config from high-level market parameters (price range, token liquidity, coin)
- New `grid_generator.py` module with pure functions: `compute_n_orders`, `compute_order_sz`, `generate_grid_config`
- Emits warnings for edge cases (below min notional, large grids without active_levels)
- No new dependencies — TOML output uses a simple f-string formatter

## Test plan

- [x] 28 new tests in `test_grid_generator.py` (math, warnings, errors, roundtrip validation)
- [x] 6 new tests in `test_cli.py` (TOML output, stderr summary, file output, invalid input)
- [x] All 75 tests pass
- [x] ruff clean, mypy clean
- [x] Smoke test: `pyperliquidity grid --coin @1434 --price-range 350 50000 --liquidity-token 40 --active-levels 20 --testnet`

🤖 Generated with [Claude Code](https://claude.com/claude-code)