### PR TITLE
Fix standalone SDK usage and websocket shutdown

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,10 @@ Hyperliquidity is parametrized by: `startPx`, `nOrders`, `orderSz`, `nSeededLeve
 
 The price is NOT computed from an AMM formula — it emerges from where the inventory sits on the grid. Filled asks become bids at the same grid level; filled bids become asks.
 
+## Tools
+
+**Use the LSP tool** for navigating this codebase — go-to-definition, find-references, hover for type info, document symbols, and call hierarchy. Prefer LSP over grep for tracing symbols and understanding call chains.
+
 ## Code Standards
 
 - Python 3.11+

--- a/src/pyperliquidity/__init__.py
+++ b/src/pyperliquidity/__init__.py
@@ -1,3 +1,7 @@
 """pyperliquidity — Off-chain HIP-2 Hyperliquidity for Hyperliquid spot markets."""
 
 __version__ = "0.3.1"
+
+from pyperliquidity.spot_meta_fix import build_exchange, build_info
+
+__all__ = ["build_exchange", "build_info"]

--- a/src/pyperliquidity/spot_meta_fix.py
+++ b/src/pyperliquidity/spot_meta_fix.py
@@ -102,3 +102,68 @@ def fetch_fixed_spot_meta(base_url: str) -> dict[str, Any]:
     resp.raise_for_status()
     raw: dict[str, Any] = resp.json()
     return fix_spot_meta(raw)
+
+
+def build_info(
+    base_url: str,
+    *,
+    skip_ws: bool = False,
+) -> Any:
+    """Build a Hyperliquid ``Info`` object with the spot_meta index fix applied.
+
+    This avoids the ``IndexError`` that occurs when constructing ``Info``
+    directly on networks where token indices diverge from array positions.
+
+    Parameters
+    ----------
+    base_url:
+        Hyperliquid API base URL (mainnet or testnet).
+    skip_ws:
+        If ``True``, skip WebSocket connection (useful for one-shot REST calls).
+
+    Returns
+    -------
+    hyperliquid.info.Info
+        A usable ``Info`` instance.
+    """
+    from hyperliquid.info import Info
+
+    fixed = fetch_fixed_spot_meta(base_url)
+    return Info(base_url=base_url, skip_ws=skip_ws, spot_meta=fixed)
+
+
+def build_exchange(
+    wallet: Any,
+    base_url: str,
+    *,
+    vault_address: str | None = None,
+    account_address: str | None = None,
+) -> Any:
+    """Build a Hyperliquid ``Exchange`` object with the spot_meta index fix applied.
+
+    Parameters
+    ----------
+    wallet:
+        An ``eth_account`` ``LocalAccount`` (from ``Account.from_key(...)``).
+    base_url:
+        Hyperliquid API base URL (mainnet or testnet).
+    vault_address:
+        Optional vault address for vault-delegated trading.
+    account_address:
+        Optional account address override.
+
+    Returns
+    -------
+    hyperliquid.exchange.Exchange
+        A usable ``Exchange`` instance.
+    """
+    from hyperliquid.exchange import Exchange
+
+    fixed = fetch_fixed_spot_meta(base_url)
+    return Exchange(
+        wallet,
+        base_url=base_url,
+        spot_meta=fixed,
+        vault_address=vault_address,
+        account_address=account_address,
+    )

--- a/src/pyperliquidity/spot_meta_fix.py
+++ b/src/pyperliquidity/spot_meta_fix.py
@@ -126,7 +126,7 @@ def build_info(
     hyperliquid.info.Info
         A usable ``Info`` instance.
     """
-    from hyperliquid.info import Info
+    from hyperliquid.info import Info  # type: ignore[import-untyped]
 
     fixed = fetch_fixed_spot_meta(base_url)
     return Info(base_url=base_url, skip_ws=skip_ws, spot_meta=fixed)
@@ -157,7 +157,7 @@ def build_exchange(
     hyperliquid.exchange.Exchange
         A usable ``Exchange`` instance.
     """
-    from hyperliquid.exchange import Exchange
+    from hyperliquid.exchange import Exchange  # type: ignore[import-untyped]
 
     fixed = fetch_fixed_spot_meta(base_url)
     return Exchange(

--- a/src/pyperliquidity/ws_state.py
+++ b/src/pyperliquidity/ws_state.py
@@ -533,6 +533,14 @@ class WsState:
 
         logger.info("Shutdown: cancelled %d order(s), order state cleared", len(oids))
 
+    def _close_websocket(self) -> None:
+        """Close the SDK WebSocket connection so daemon threads can exit."""
+        try:
+            self._info.disconnect_websocket()
+            logger.info("Shutdown: WebSocket disconnected")
+        except Exception:
+            logger.debug("Shutdown: disconnect_websocket failed (may already be closed)")
+
     # -- Main entry point ------------------------------------------------------
 
     async def run(self) -> None:
@@ -559,3 +567,4 @@ class WsState:
 
         await self._tick_loop()
         await self._shutdown()
+        self._close_websocket()


### PR DESCRIPTION
## Summary
- **#54**: Add `build_info()` and `build_exchange()` helpers to `spot_meta_fix.py` that apply the index fix before constructing SDK objects. Exported from `pyperliquidity` top-level so standalone scripts can build usable SDK objects without the full MM flow.
- **#53**: Call `info.disconnect_websocket()` after graceful shutdown so the SDK's `WebsocketManager` threads exit cleanly instead of hanging the process.

## Test plan
- [x] All 340 existing tests pass
- [ ] Verify standalone `build_info()`/`build_exchange()` work on testnet without `IndexError`
- [ ] Verify process exits cleanly after SIGTERM (no hanging websocket threads)

Closes #54, closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)